### PR TITLE
Add default `tile_size` for zarr writer

### DIFF
--- a/wsireg/utils/im_utils.py
+++ b/wsireg/utils/im_utils.py
@@ -1149,7 +1149,7 @@ def get_final_yx_from_tform(tform_reg_im, final_transform):
     return y_size, x_size, y_spacing, x_spacing
 
 
-def transform_to_ome_zarr(tform_reg_im, output_dir, tile_size):
+def transform_to_ome_zarr(tform_reg_im, output_dir, tile_size=512):
 
     y_size, x_size = get_final_yx_from_tform(tform_reg_im)
 


### PR DESCRIPTION
Getting the chance to try this out on a project! Thanks for making this open-source.

This PR adds a default `tile_size` to parity the default in `transform_to_ome_tiff`. I ran a workflow and unfortunately it crashed on the last step because I forgot this argument.