### PR TITLE
Add handling of non-interleaved RGB images for most reg image subclasses

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import pytest
 from tests.fixtures.im_fixtures import (
     im_rgb_np,
     im_mch_np,
+    im_mch_np_uint8,
     im_gry_np,
     mask_np,
     disk_im_mch,

--- a/tests/fixtures/im_fixtures.py
+++ b/tests/fixtures/im_fixtures.py
@@ -21,6 +21,11 @@ def im_mch_np():
 
 
 @pytest.fixture
+def im_mch_np_uint8():
+    return np.random.randint(0, 255, (3, 2048, 2048), dtype=np.uint8)
+
+
+@pytest.fixture
 def im_rgb_np():
     return np.random.randint(0, 255, (2048, 2048, 3), dtype=np.uint8)
 

--- a/tests/test_reg_image.py
+++ b/tests/test_reg_image.py
@@ -272,3 +272,27 @@ def test_reg_image_loader_to_itk(im_gry_np, mask_np):
     assert reg_image.image.GetSpacing() == (0.65, 0.65)
     assert isinstance(reg_image.mask, itk.Image) is True
     assert reg_image.mask.GetSpacing() == (0.65, 0.65)
+
+
+@pytest.mark.usefixtures("im_mch_np_uint8")
+def test_reg_image_loader_np_8bit_force_rgb(im_mch_np_uint8):
+    reg_image = reg_image_loader(
+        im_mch_np_uint8, 0.65, preprocessing={"set_rgb": True}
+    )
+    reg_image.read_reg_image()
+    assert reg_image.image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.is_rgb is True
+    assert reg_image.is_rgb_interleaved is False
+
+
+@pytest.mark.usefixtures("im_mch_np_uint8")
+def test_reg_image_loader_np_8bit_force_rgb_off(im_mch_np_uint8):
+    reg_image = reg_image_loader(
+        im_mch_np_uint8, 0.65, preprocessing={"set_rgb": False}
+    )
+    reg_image.read_reg_image()
+    assert reg_image.image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.is_rgb is False
+    assert reg_image.is_rgb_interleaved is False

--- a/tests/test_wsireg.py
+++ b/tests/test_wsireg.py
@@ -307,3 +307,23 @@ def test_wsireg_run_reg_with_crop_merge(data_out_dir, disk_im_gry):
 
     assert registered_image_nocrop.im_dims[1:] == (2048, 2048)
     assert registered_image_crop.im_dims[1:] == (512, 512)
+
+
+@pytest.mark.usefixtures("im_mch_np_uint8")
+def test_wsireg_run_reg_with_crop_merge(data_out_dir, im_mch_np_uint8):
+    wsi_reg = WsiReg2D("test_proj10", str(data_out_dir))
+
+    wsi_reg.add_modality(
+        "mod1", im_mch_np_uint8, 0.65, prepro_dict={"set_rgb": True}
+    )
+
+    wsi_reg.add_modality("mod2", im_mch_np_uint8, 0.65)
+
+    wsi_reg.add_reg_path("mod1", "mod2", reg_params=["rigid_test"])
+    wsi_reg.register_images()
+
+    im_fps = wsi_reg.transform_images(transform_non_reg=False)
+
+    registered_image = reg_image_loader(im_fps[0], 0.65)
+
+    assert registered_image.im_dims == (2048, 2048, 3)

--- a/wsireg/reg_images/np_reg_image.py
+++ b/wsireg/reg_images/np_reg_image.py
@@ -136,7 +136,7 @@ class NumpyRegImage(RegImage):
             )
             channel_idx = 0
         if self.n_ch > 1:
-            if self.is_rgb and self.is_rgb_interleaved is True:
+            if self.is_rgb and self.is_rgb_interleaved:
                 image = self.image[:, :, channel_idx]
             else:
                 image = self.image[channel_idx, :, :]

--- a/wsireg/reg_images/ometiff_reg_image.py
+++ b/wsireg/reg_images/ometiff_reg_image.py
@@ -48,6 +48,15 @@ class OmeTiffRegImage(RegImage):
             self.preprocessing = std_prepro()
             self.preprocessing.update(preprocessing)
 
+        if self.preprocessing.get("set_rgb") is True:
+            if self.is_rgb is False:
+                self.is_rgb = True
+                self.is_rgb_interleaved = False
+        elif self.preprocessing.get("set_rgb") is False:
+            if self.is_rgb is True:
+                self.is_rgb = False
+                self.is_rgb_interleaved = True
+
         self.pre_reg_transforms = pre_reg_transforms
 
         self.channel_names = channel_names

--- a/wsireg/reg_images/reg_image.py
+++ b/wsireg/reg_images/reg_image.py
@@ -85,6 +85,7 @@ class RegImage:
                 preprocessing.pop(spat_key, None)
 
         # remove read time preprocessing
+        preprocessing.pop("set_rgb", None)
         preprocessing.pop("ch_indices", None)
         preprocessing.pop("as_uint8", None)
 

--- a/wsireg/utils/im_utils.py
+++ b/wsireg/utils/im_utils.py
@@ -1140,11 +1140,22 @@ def get_final_yx_from_tform(tform_reg_im, final_transform):
             final_transform
         )
     else:
-        y_size, x_size = (
-            (tform_reg_im.im_dims[0], tform_reg_im.im_dims[1])
-            if tform_reg_im.is_rgb
-            else (tform_reg_im.im_dims[1], tform_reg_im.im_dims[2])
-        )
+        if tform_reg_im.is_rgb is True:
+            if (
+                tform_reg_im.is_rgb_interleaved is None
+                or tform_reg_im.is_rgb_interleaved is True
+            ):
+                y_size, x_size = (
+                    tform_reg_im.im_dims[0],
+                    tform_reg_im.im_dims[1],
+                )
+            elif tform_reg_im.is_rgb_interleaved is False:
+                y_size, x_size = (
+                    tform_reg_im.im_dims[1],
+                    tform_reg_im.im_dims[2],
+                )
+        else:
+            y_size, x_size = (tform_reg_im.im_dims[1], tform_reg_im.im_dims[2])
         y_spacing, x_spacing = None, None
     return y_size, x_size, y_spacing, x_spacing
 
@@ -1245,11 +1256,8 @@ def transform_to_ome_tiff(
     while y_size / tile_size <= 1 or x_size / tile_size <= 1:
         tile_size = tile_size // 2
 
-    n_ch = (
-        tform_reg_im.im_dims[2]
-        if tform_reg_im.is_rgb
-        else tform_reg_im.im_dims[0]
-    )
+    n_ch = tform_reg_im.n_ch
+
     pyr_levels, pyr_shapes = get_pyramid_info(y_size, x_size, n_ch, tile_size)
     n_pyr_levels = len(pyr_levels)
     output_file_name = str(Path(output_dir) / image_name)

--- a/wsireg/wsireg2d.py
+++ b/wsireg/wsireg2d.py
@@ -811,6 +811,7 @@ class WsiReg2D(object):
             im_data["image_res"],
             channel_names=im_data.get("channel_names"),
             channel_colors=im_data.get("channel_colors"),
+            preprocessing=im_data.get("preprocessing"),
         )
         im_fp = tfregimage.transform_image(
             output_path.stem,
@@ -862,6 +863,7 @@ class WsiReg2D(object):
             im_data["image_res"],
             channel_names=im_data.get("channel_names"),
             channel_colors=im_data.get("channel_colors"),
+            preprocessing=im_data.get("preprocessing"),
         )
         im_fp = tfregimage.transform_image(
             output_path.stem,


### PR DESCRIPTION
This addition allows you to pass `set_rgb` key with a boolean value in the `preprocessing` dictionary where `True` sets the image to RGB, even if it is not interleaved so that the final transformed, resampled image will be stored as RGB interleaved. This doesn't yet work with `OME-zarr` writer. 

example:
```python
import numpy as np
from wsireg.wsireg2d import WsiReg2D

rgb_deinterleaved_arr = np.random.randint(0, 255, (3, 2048, 2048), dtype=np.uint8)

# initialize registration graph
reg_graph = WsiReg2D("my_reg_project", "./project_folder")

reg_graph.add_modality(
    "modality_BF",
    rgb_deinterleaved_arr,
    image_res=0.65,
    prepro_dict={
        "image_type": "BF",
        "set_rgb":True # set to non-interleaved
    },
)
```

@manzt Give this a shot and see if it helps. I'll overhaul the `OME-zarr` writing soon. A little hesitant there because I know v0.2 is solidifying. 