### PR TITLE
make all images loaded by `tifffile` go to `array_like` and use `NumpyRegImage`

### DIFF
--- a/tests/test_im_read.py
+++ b/tests/test_im_read.py
@@ -224,8 +224,6 @@ def test_ometiff_read_rgb():
     assert len(ri.im_dims) == 3
     assert ri.im_dtype == np.uint8
     assert ri.is_rgb is True
-    assert ri.is_rgb_interleaved is False
-
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
 def test_ometiff_read_rgb_default_preprocess():
@@ -245,8 +243,6 @@ def test_ometiff_read_mc():
     assert ri.im_dims[2] > 3
     assert ri.im_dtype == np.uint16
     assert ri.is_rgb is False
-    assert ri.is_rgb_interleaved is False
-
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
 def test_ometiff_read_mc_default_preprocess():
@@ -293,9 +289,9 @@ def test_czi_read_rgb_read_channels():
     ch1 = ri.read_single_channel(1)
     ch2 = ri.read_single_channel(2)
 
-    assert np.squeeze(ch0).shape == ri.im_dims[1:]
-    assert np.squeeze(ch1).shape == ri.im_dims[1:]
-    assert np.squeeze(ch2).shape == ri.im_dims[1:]
+    assert np.squeeze(ch0).shape == ri.im_dims[:2]
+    assert np.squeeze(ch1).shape == ri.im_dims[:2]
+    assert np.squeeze(ch2).shape == ri.im_dims[:2]
     assert np.ndim(ch0) == 2
     assert np.ndim(ch1) == 2
     assert np.ndim(ch2) == 2

--- a/wsireg/reg_images/loader.py
+++ b/wsireg/reg_images/loader.py
@@ -3,11 +3,14 @@ from tifffile import TiffFile
 from wsireg.reg_images import (
     CziRegImage,
     SitkRegImage,
-    TiffFileRegImage,
     NumpyRegImage,
-    OmeTiffRegImage,
 )
-from wsireg.utils.im_utils import TIFFFILE_EXTS, ARRAYLIKE_CLASSES
+from wsireg.utils.im_utils import (
+    TIFFFILE_EXTS,
+    ARRAYLIKE_CLASSES,
+    tifffile_to_arraylike,
+    ome_tifffile_to_arraylike,
+)
 
 
 def reg_image_loader(
@@ -33,7 +36,8 @@ def reg_image_loader(
     image_ext = Path(image).suffix
     if image_ext in TIFFFILE_EXTS:
         if TiffFile(image).is_ome:
-            reg_image = OmeTiffRegImage(
+            image = ome_tifffile_to_arraylike(image)
+            reg_image = NumpyRegImage(
                 image,
                 image_res,
                 mask,
@@ -43,7 +47,8 @@ def reg_image_loader(
                 channel_colors,
             )
         else:
-            reg_image = TiffFileRegImage(
+            image = tifffile_to_arraylike(image)
+            reg_image = NumpyRegImage(
                 image,
                 image_res,
                 mask,


### PR DESCRIPTION
PR is the first step to centralizing all image pre-processing and reading around Dask. This works for all `tifffile` image format but not yet for `czi` because `czifile` doesn't map the blocks to dask. `aicsimageio` does this now, but still debating it as a dependency. 