### PR TITLE
Update `RegImage` file type subclasses

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.1
+current_version = 0.3.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/nhpatterson/wsireg',
-    version='0.2.1',
+    version='0.3.0',
     zip_safe=False,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,10 @@ from tests.fixtures.im_fixtures import (
     disk_im_mch,
     disk_im_rgb,
     disk_im_gry,
+    disk_im_mch_notile,
+    disk_im_gry_pyr,
+    disk_im_mch_pyr,
+    disk_im_rgb_pyr,
 )
 from tests.fixtures.transform_fixtures import (
     complex_transform,

--- a/tests/fixtures/im_fixtures.py
+++ b/tests/fixtures/im_fixtures.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 import dask.array as da
 import zarr
-from tifffile import imwrite
+from tifffile import TiffWriter, imwrite, imread
 
 
 @pytest.fixture
@@ -70,19 +70,110 @@ def zarr_im_rgb_np():
 @pytest.fixture
 def disk_im_mch(tmpdir_factory, im_mch_np):
     out_im = tmpdir_factory.mktemp("image").join("image_fp_mch.tiff")
-    imwrite(out_im, im_mch_np)
+    imwrite(out_im, im_mch_np, tile=(256, 256))
     return out_im
 
+@pytest.fixture
+def disk_im_mch_notile(tmpdir_factory, im_mch_np):
+    out_im = tmpdir_factory.mktemp("image").join("image_fp_mch_nt.tiff")
+    imwrite(out_im, im_mch_np, photometric="MINISBLACK", tile=(256,256))
+    return out_im
 
 @pytest.fixture
 def disk_im_rgb(tmpdir_factory, im_rgb_np):
     out_im = tmpdir_factory.mktemp("image").join("image_fp_rgb.tiff")
-    imwrite(out_im, im_rgb_np)
+    imwrite(out_im, im_rgb_np, tile=(256, 256))
     return out_im
 
 
 @pytest.fixture
 def disk_im_gry(tmpdir_factory, im_gry_np):
     out_im = tmpdir_factory.mktemp("image").join("image_fp_gry.tiff")
-    imwrite(out_im, im_gry_np)
+    imwrite(out_im, im_gry_np, tile=(256, 256))
+    return out_im
+
+
+@pytest.fixture
+def disk_im_mch_pyr(tmpdir_factory):
+    out_im = tmpdir_factory.mktemp("image").join("image_fp_mch_pyr.tiff")
+    subifds = 2
+    full_im = np.random.randint(0, 255, (3, 2048, 2048), dtype=np.uint16)
+    with TiffWriter(out_im) as tif:
+        for ch in range(full_im.shape[0]):
+            options = dict(
+                tile=(256, 256),
+                compression="deflate",
+                photometric="minisblack",
+                metadata=None,
+            )
+            tif.write(
+                full_im[ch, :, :],
+                subifds=subifds,
+                **options,
+            )
+
+            for pyr_idx in range(subifds):
+                if pyr_idx == 0:
+                    subresimage = full_im[ch, ::2, ::2]
+                else:
+                    subresimage = subresimage[::2, ::2]
+
+                tif.write(subresimage, **options, subfiletype=1)
+    return out_im
+
+
+@pytest.fixture
+def disk_im_rgb_pyr(tmpdir_factory):
+    out_im = tmpdir_factory.mktemp("image").join("image_fp_rgb_pyr.tiff")
+    subifds = 2
+    full_im = np.random.randint(0, 255, (2048, 2048, 3), dtype=np.uint8)
+    with TiffWriter(out_im) as tif:
+        options = dict(
+            tile=(128, 128),
+            compression="deflate",
+            photometric="rgb",
+            metadata=None,
+        )
+        tif.write(
+            full_im,
+            subifds=subifds,
+            **options,
+        )
+
+        for pyr_idx in range(subifds):
+            if pyr_idx == 0:
+                subresimage = full_im[::2, ::2, :]
+            else:
+                subresimage = subresimage[::2, ::2, :]
+
+            tif.write(subresimage, **options, subfiletype=1)
+
+    return out_im
+
+
+@pytest.fixture
+def disk_im_gry_pyr(tmpdir_factory):
+    out_im = tmpdir_factory.mktemp("image").join("image_fp_gry_pyr.tiff")
+    subifds = 2
+    full_im = np.random.randint(0, 255, (2048, 2048), dtype=np.uint16)
+    with TiffWriter(out_im) as tif:
+        options = dict(
+            tile=(256, 256),
+            compression="deflate",
+            photometric="minisblack",
+            metadata=None,
+        )
+        tif.write(
+            full_im,
+            subifds=subifds,
+            **options,
+        )
+
+        for pyr_idx in range(subifds):
+            if pyr_idx == 0:
+                subresimage = full_im[::2, ::2]
+            else:
+                subresimage = subresimage[::2, ::2]
+
+            tif.write(subresimage, **options, subfiletype=1)
     return out_im

--- a/tests/test_im_read.py
+++ b/tests/test_im_read.py
@@ -31,7 +31,7 @@ def test_czi_read_rgb_default_preprocess():
     image_fp = os.path.join(PRIVATE_DIR, "czi_rgb.czi")
     ri = reg_image_loader(image_fp, 1)
     ri.read_reg_image()
-    assert ri.image.GetNumberOfComponentsPerPixel() == 1
+    assert ri.reg_image.GetNumberOfComponentsPerPixel() == 1
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
@@ -40,7 +40,7 @@ def test_czi_read_rgb_bf_preprocess():
     preprocessing = {"image_type": "BF"}
     ri = reg_image_loader(image_fp, 1, preprocessing=preprocessing)
     ri.read_reg_image()
-    assert ri.image.GetNumberOfComponentsPerPixel() == 1
+    assert ri.reg_image.GetNumberOfComponentsPerPixel() == 1
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
@@ -59,8 +59,8 @@ def test_czi_read_mc_default_preprocess():
     image_fp = os.path.join(PRIVATE_DIR, "czi_4ch_16bit.czi")
     ri = reg_image_loader(image_fp, 1)
     ri.read_reg_image()
-    assert ri.image.GetNumberOfComponentsPerPixel() == 1
-    assert ri.image.GetPixelID() == 1
+    assert ri.reg_image.GetNumberOfComponentsPerPixel() == 1
+    assert ri.reg_image.GetPixelID() == 1
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
@@ -69,8 +69,8 @@ def test_czi_read_mc_fl_preprocess():
     preprocessing = {"image_type": "FL", "as_uint8": True}
     ri = reg_image_loader(image_fp, 1, preprocessing=preprocessing)
     ri.read_reg_image()
-    assert ri.image.GetNumberOfComponentsPerPixel() == 1
-    assert ri.image.GetPixelID() == 1
+    assert ri.reg_image.GetNumberOfComponentsPerPixel() == 1
+    assert ri.reg_image.GetPixelID() == 1
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
@@ -79,8 +79,8 @@ def test_czi_read_mc_std_preprocess():
     preprocessing = std_prepro()
     ri = reg_image_loader(image_fp, 1, preprocessing=preprocessing)
     ri.read_reg_image()
-    assert ri.image.GetNumberOfComponentsPerPixel() == 1
-    assert ri.image.GetPixelID() == 1
+    assert ri.reg_image.GetNumberOfComponentsPerPixel() == 1
+    assert ri.reg_image.GetPixelID() == 1
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
@@ -89,8 +89,8 @@ def test_czi_read_mc_selectch_preprocess():
     preprocessing = {"ch_indices": [0]}
     ri = reg_image_loader(image_fp, 1, preprocessing=preprocessing)
     ri.read_reg_image()
-    assert ri.image.GetNumberOfComponentsPerPixel() == 1
-    assert ri.image.GetPixelID() == 1
+    assert ri.reg_image.GetNumberOfComponentsPerPixel() == 1
+    assert ri.reg_image.GetPixelID() == 1
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
@@ -99,8 +99,8 @@ def test_czi_read_mc_selectch_preprocess():
     preprocessing = {"ch_indices": 0}
     ri = reg_image_loader(image_fp, 1, preprocessing=preprocessing)
     ri.read_reg_image()
-    assert ri.image.GetNumberOfComponentsPerPixel() == 1
-    assert ri.image.GetPixelID() == 1
+    assert ri.reg_image.GetNumberOfComponentsPerPixel() == 1
+    assert ri.reg_image.GetPixelID() == 1
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
@@ -169,7 +169,7 @@ def test_scn_read_rgb_default_preprocess():
     image_fp = os.path.join(PRIVATE_DIR, "scn_rgb.scn")
     ri = reg_image_loader(image_fp, 1)
     ri.read_reg_image()
-    assert ri.image.GetNumberOfComponentsPerPixel() == 1
+    assert ri.reg_image.GetNumberOfComponentsPerPixel() == 1
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
@@ -178,7 +178,7 @@ def test_scn_read_rgb_bf_preprocess():
     preprocessing = {"image_type": "BF"}
     ri = reg_image_loader(image_fp, 1, preprocessing=preprocessing)
     ri.read_reg_image()
-    assert ri.image.GetNumberOfComponentsPerPixel() == 1
+    assert ri.reg_image.GetNumberOfComponentsPerPixel() == 1
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
@@ -196,7 +196,7 @@ def test_huron_read_rgb_default_preprocess():
     image_fp = os.path.join(PRIVATE_DIR, "huron_rgb.tif")
     ri = reg_image_loader(image_fp, 1)
     ri.read_reg_image()
-    assert ri.image.GetNumberOfComponentsPerPixel() == 1
+    assert ri.reg_image.GetNumberOfComponentsPerPixel() == 1
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
@@ -205,7 +205,7 @@ def test_huron_read_rgb_bf_preprocess():
     preprocessing = {"image_type": "BF"}
     ri = reg_image_loader(image_fp, 1, preprocessing=preprocessing)
     ri.read_reg_image()
-    assert ri.image.GetNumberOfComponentsPerPixel() == 1
+    assert ri.reg_image.GetNumberOfComponentsPerPixel() == 1
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
@@ -214,7 +214,7 @@ def test_huron_read_rgb_bf_preprocess():
     preprocessing = {"image_type": "BF"}
     ri = reg_image_loader(image_fp, 1, preprocessing=preprocessing)
     ri.read_reg_image()
-    assert ri.image.GetNumberOfComponentsPerPixel() == 1
+    assert ri.reg_image.GetNumberOfComponentsPerPixel() == 1
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
@@ -231,7 +231,7 @@ def test_ometiff_read_rgb_default_preprocess():
     image_fp = os.path.join(PRIVATE_DIR, "czi_rgb.ome.tiff")
     ri = reg_image_loader(image_fp, 1)
     ri.read_reg_image()
-    assert ri.image.GetNumberOfComponentsPerPixel() == 1
+    assert ri.reg_image.GetNumberOfComponentsPerPixel() == 1
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
@@ -251,7 +251,7 @@ def test_ometiff_read_mc_default_preprocess():
     image_fp = os.path.join(PRIVATE_DIR, "czi_4ch_16bit.ome.tiff")
     ri = reg_image_loader(image_fp, 1)
     ri.read_reg_image()
-    assert ri.image.GetNumberOfComponentsPerPixel() == 1
+    assert ri.reg_image.GetNumberOfComponentsPerPixel() == 1
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)

--- a/tests/test_im_utils.py
+++ b/tests/test_im_utils.py
@@ -1,0 +1,438 @@
+import pytest
+import os
+import numpy as np
+import zarr
+import dask.array as da
+from tifffile import imread
+from wsireg.utils.im_utils import (
+    zarr_get_base_pyr_layer,
+    ensure_dask_array,
+    read_preprocess_array,
+    tifffile_zarr_backend,
+    tifffile_dask_backend,
+    sitk_backend,
+    guess_rgb,
+    grayscale,
+    czi_tile_grayscale,
+    CziRegImageReader,
+    tf_get_largest_series,
+    get_sitk_image_info,
+    get_tifffile_info
+)
+
+# private data logic borrowed from https://github.com/cgohlke/tifffile/tests/test_tifffile.py
+HERE = os.path.dirname(__file__)
+PRIVATE_DIR = os.path.join(HERE, "private_data")
+
+SKIP_PRIVATE = False
+REASON = "private data"
+
+if not os.path.exists(PRIVATE_DIR):
+    SKIP_PRIVATE = True
+
+
+@pytest.mark.usefixtures(
+    "disk_im_gry_pyr",
+    "disk_im_mch_pyr",
+    "disk_im_rgb_pyr",
+    "disk_im_gry",
+    "disk_im_mch",
+    "disk_im_rgb",
+)
+def test_zarr_get_base_pyr_layer(
+    disk_im_gry_pyr,
+    disk_im_mch_pyr,
+    disk_im_rgb_pyr,
+    disk_im_gry,
+    disk_im_mch,
+    disk_im_rgb,
+):
+    zarr_store = zarr.open(imread(disk_im_gry_pyr, aszarr=True))
+    gry_zarray_from_pyr = zarr_get_base_pyr_layer(zarr_store)
+
+    zarr_store = zarr.open(imread(disk_im_mch_pyr, aszarr=True))
+    mch_zarray_from_pyr = zarr_get_base_pyr_layer(zarr_store)
+
+    zarr_store = zarr.open(imread(disk_im_rgb_pyr, aszarr=True))
+    rgb_zarray_from_pyr = zarr_get_base_pyr_layer(zarr_store)
+
+    zarr_store = zarr.open(imread(disk_im_gry, aszarr=True))
+    gry_zarray_from_flat = zarr_get_base_pyr_layer(zarr_store)
+
+    zarr_store = zarr.open(imread(disk_im_mch, aszarr=True))
+    mch_zarray_from_flat = zarr_get_base_pyr_layer(zarr_store)
+
+    zarr_store = zarr.open(imread(disk_im_rgb, aszarr=True))
+    rgb_zarray_from_flat = zarr_get_base_pyr_layer(zarr_store)
+
+    assert gry_zarray_from_pyr.shape == (2048, 2048)
+    assert mch_zarray_from_pyr.shape == (3, 2048, 2048)
+    assert rgb_zarray_from_pyr.shape == (2048, 2048, 3)
+    assert gry_zarray_from_flat.shape == (2048, 2048)
+    assert mch_zarray_from_flat.shape == (3, 2048, 2048)
+    assert rgb_zarray_from_flat.shape == (2048, 2048, 3)
+
+
+def test_ensure_dask_array():
+    np_arr = np.zeros((128, 128, 3), dtype=np.uint8)
+    da_arr = da.zeros((128, 128, 3), dtype=np.uint8)
+    za_arr = zarr.zeros((128, 128, 3), dtype=np.uint8)
+
+    np_out = ensure_dask_array(np_arr)
+    da_out = ensure_dask_array(da_arr)
+    za_out = ensure_dask_array(za_arr)
+
+    assert isinstance(np_out, da.Array)
+    assert isinstance(da_out, da.Array)
+    assert isinstance(za_out, da.Array)
+
+
+def test_read_preprocess_array():
+    da_arr = ensure_dask_array(np.zeros((128, 128, 3), dtype=np.uint8))
+    mc_arr = ensure_dask_array(np.zeros((3, 128, 128), dtype=np.uint8))
+    gr_arr = ensure_dask_array(np.zeros((128, 128), dtype=np.uint8))
+
+    std_rgb = read_preprocess_array(
+        da_arr, preprocessing={"image_type": "BF"}, force_rgb=None
+    )
+    nonstd_rgb = read_preprocess_array(
+        mc_arr, preprocessing={"image_type": "BF"}, force_rgb=True
+    )
+
+    all_ch_mc = read_preprocess_array(
+        mc_arr, preprocessing={"image_type": "FL"}
+    )
+
+    ch0_ch_mc = read_preprocess_array(
+        mc_arr, preprocessing={"ch_indices": [0]}
+    )
+    ch01_ch_mc = read_preprocess_array(
+        mc_arr, preprocessing={"ch_indices": [0, 1]}
+    )
+    ch12_ch_mc = read_preprocess_array(
+        mc_arr, preprocessing={"ch_indices": [1, 2]}
+    )
+    ch02_ch_mc = read_preprocess_array(
+        mc_arr, preprocessing={"ch_indices": [0, 2]}
+    )
+    ch1_ch_mc = read_preprocess_array(
+        mc_arr, preprocessing={"ch_indices": [1]}
+    )
+    ch2_ch_mc = read_preprocess_array(
+        mc_arr, preprocessing={"ch_indices": [2]}
+    )
+
+    std_gr = read_preprocess_array(gr_arr, preprocessing={"image_type": "FL"})
+    chsel0_gr = read_preprocess_array(
+        gr_arr, preprocessing={"ch_indices": [0]}
+    )
+    chsel01_gr = read_preprocess_array(
+        gr_arr, preprocessing={"ch_indices": [0, 1]}
+    )
+
+    assert std_rgb.GetNumberOfComponentsPerPixel() == 1
+    assert nonstd_rgb.GetNumberOfComponentsPerPixel() == 1
+    assert all_ch_mc.GetDepth() == 3
+    assert ch0_ch_mc.GetDepth() == 0
+    assert ch01_ch_mc.GetDepth() == 2
+    assert ch12_ch_mc.GetDepth() == 2
+    assert ch02_ch_mc.GetDepth() == 2
+    assert ch1_ch_mc.GetDepth() == 0
+    assert ch2_ch_mc.GetDepth() == 0
+    assert std_gr.GetDepth() == 0
+    assert chsel0_gr.GetDepth() == 0
+    assert chsel01_gr.GetDepth() == 0
+    assert std_rgb.GetSize() == (128, 128)
+    assert nonstd_rgb.GetSize() == (128, 128)
+    assert all_ch_mc.GetSize() == (128, 128, 3)
+    assert ch0_ch_mc.GetSize() == (128, 128)
+    assert ch01_ch_mc.GetSize() == (128, 128, 2)
+    assert ch12_ch_mc.GetSize() == (128, 128, 2)
+    assert ch02_ch_mc.GetSize() == (128, 128, 2)
+    assert ch1_ch_mc.GetSize() == (128, 128)
+    assert ch2_ch_mc.GetSize() == (128, 128)
+    assert std_gr.GetSize() == (128, 128)
+    assert chsel0_gr.GetSize() == (128, 128)
+    assert chsel01_gr.GetSize() == (128, 128)
+
+
+@pytest.mark.usefixtures(
+    "disk_im_gry_pyr",
+    "disk_im_mch_pyr",
+    "disk_im_rgb_pyr",
+    "disk_im_gry",
+    "disk_im_mch",
+    "disk_im_rgb",
+)
+def test_tifffile_zarr_backend(
+    disk_im_gry_pyr,
+    disk_im_mch_pyr,
+    disk_im_rgb_pyr,
+    disk_im_gry,
+    disk_im_mch,
+    disk_im_rgb,
+):
+    im_gry_pyr = tifffile_zarr_backend(
+        disk_im_gry_pyr, largest_series=0, preprocessing={"image_type": "FL"}
+    )
+    im_mch_pyr = tifffile_zarr_backend(
+        disk_im_mch_pyr, largest_series=0, preprocessing={"image_type": "FL"}
+    )
+    im_rgb_pyr = tifffile_zarr_backend(
+        disk_im_rgb_pyr, largest_series=0, preprocessing={"image_type": "BF"}
+    )
+    im_gry = tifffile_zarr_backend(
+        disk_im_gry, largest_series=0, preprocessing={"image_type": "FL"}
+    )
+    im_mch = tifffile_zarr_backend(
+        disk_im_mch, largest_series=0, preprocessing={"image_type": "FL"}
+    )
+    im_rgb = tifffile_zarr_backend(
+        disk_im_rgb, largest_series=0, preprocessing={"image_type": "BF"}
+    )
+
+    assert im_gry_pyr.GetSize() == (2048, 2048)
+    assert im_mch_pyr.GetSize() == (2048, 2048, 3)
+    assert im_rgb_pyr.GetSize() == (2048, 2048)
+    assert im_gry.GetSize() == (2048, 2048)
+    assert im_mch.GetSize() == (2048, 2048, 3)
+    assert im_rgb.GetSize() == (2048, 2048)
+
+
+@pytest.mark.usefixtures(
+    "disk_im_gry_pyr",
+    "disk_im_mch_pyr",
+    "disk_im_rgb_pyr",
+    "disk_im_gry",
+    "disk_im_mch",
+    "disk_im_rgb",
+)
+def test_tifffile_dask_backend(
+    disk_im_gry_pyr,
+    disk_im_mch_pyr,
+    disk_im_rgb_pyr,
+    disk_im_gry,
+    disk_im_mch,
+    disk_im_rgb,
+):
+    im_gry_pyr = tifffile_dask_backend(
+        disk_im_gry_pyr, largest_series=0, preprocessing={"image_type": "FL"}
+    )
+    im_mch_pyr = tifffile_dask_backend(
+        disk_im_mch_pyr, largest_series=0, preprocessing={"image_type": "FL"}
+    )
+    im_rgb_pyr = tifffile_dask_backend(
+        disk_im_rgb_pyr, largest_series=0, preprocessing={"image_type": "BF"}
+    )
+    im_gry = tifffile_dask_backend(
+        disk_im_gry, largest_series=0, preprocessing={"image_type": "FL"}
+    )
+    im_mch = tifffile_dask_backend(
+        disk_im_mch, largest_series=0, preprocessing={"image_type": "FL"}
+    )
+    im_rgb = tifffile_dask_backend(
+        disk_im_rgb, largest_series=0, preprocessing={"image_type": "BF"}
+    )
+
+    assert im_gry_pyr.GetSize() == (2048, 2048)
+    assert im_mch_pyr.GetSize() == (2048, 2048, 3)
+    assert im_rgb_pyr.GetSize() == (2048, 2048)
+    assert im_gry.GetSize() == (2048, 2048)
+    assert im_mch.GetSize() == (2048, 2048, 3)
+    assert im_rgb.GetSize() == (2048, 2048)
+
+
+@pytest.mark.usefixtures(
+    "disk_im_gry_pyr",
+    "disk_im_mch_pyr",
+    "disk_im_rgb_pyr",
+    "disk_im_gry",
+    "disk_im_mch",
+    "disk_im_rgb",
+)
+def test_tifffile_dask_backend(
+    disk_im_gry_pyr,
+    disk_im_mch_pyr,
+    disk_im_rgb_pyr,
+    disk_im_gry,
+    disk_im_mch,
+    disk_im_rgb,
+):
+    im_gry_pyr = tifffile_dask_backend(
+        disk_im_gry_pyr, largest_series=0, preprocessing={"image_type": "FL"}
+    )
+    im_mch_pyr = tifffile_dask_backend(
+        disk_im_mch_pyr, largest_series=0, preprocessing={"image_type": "FL"}
+    )
+    im_rgb_pyr = tifffile_dask_backend(
+        disk_im_rgb_pyr, largest_series=0, preprocessing={"image_type": "BF"}
+    )
+    im_gry = tifffile_dask_backend(
+        disk_im_gry, largest_series=0, preprocessing={"image_type": "FL"}
+    )
+    im_mch = tifffile_dask_backend(
+        disk_im_mch, largest_series=0, preprocessing={"image_type": "FL"}
+    )
+    im_rgb = tifffile_dask_backend(
+        disk_im_rgb, largest_series=0, preprocessing={"image_type": "BF"}
+    )
+
+    assert im_gry_pyr.GetSize() == (2048, 2048)
+    assert im_mch_pyr.GetSize() == (2048, 2048, 3)
+    assert im_rgb_pyr.GetSize() == (2048, 2048)
+    assert im_gry.GetSize() == (2048, 2048)
+    assert im_mch.GetSize() == (2048, 2048, 3)
+    assert im_rgb.GetSize() == (2048, 2048)
+
+
+@pytest.mark.usefixtures(
+    "disk_im_gry",
+    "disk_im_mch_notile",
+    "disk_im_rgb",
+)
+def test_sitk_backend(
+    disk_im_gry,
+    disk_im_mch_notile,
+    disk_im_rgb,
+):
+
+    im_gry = sitk_backend(str(disk_im_gry), preprocessing={"image_type": "FL"})
+    # im_mch = sitk_backend(str(disk_im_mch_notile), preprocessing={"image_type":"FL"})
+    im_rgb = sitk_backend(str(disk_im_rgb), preprocessing={"image_type": "BF"})
+
+    assert im_gry.GetSize() == (2048, 2048)
+    # assert im_mch.GetSize() == (2048,2048,3)
+    assert im_rgb.GetSize() == (2048, 2048)
+
+
+def test_guess_rgb():
+    imshape_gs = (2048, 2048)
+    imshape_mch = (3, 2048, 2048)
+    imshape_rgb = (2048, 2048, 3)
+    imshape_rgba = (2048, 2048, 4)
+
+    assert guess_rgb(imshape_gs) is False
+    assert guess_rgb(imshape_mch) is False
+    assert guess_rgb(imshape_rgb) is True
+    assert guess_rgb(imshape_rgba) is True
+
+
+def test_greyscale():
+    rgb_image_il = np.ones((2048, 2048, 3), dtype=np.uint8)
+    rgb_image_noil = np.ones((3, 2048, 2048), dtype=np.uint8)
+
+    da_rgb_image_il = da.ones(
+        (2048, 2048, 3), dtype=np.uint8, chunks=(512, 512, 3)
+    )
+    da_rgb_image_noil = da.ones(
+        (3, 2048, 2048), dtype=np.uint8, chunks=(512, 512, 3)
+    )
+
+    gs_il = grayscale(rgb_image_il, is_interleaved=True)
+    gs_noil = grayscale(rgb_image_noil, is_interleaved=False)
+
+    da_gs_il = grayscale(da_rgb_image_il, is_interleaved=True)
+    da_gs_noil = grayscale(da_rgb_image_noil, is_interleaved=False)
+
+    assert gs_il.shape == (2048, 2048)
+    assert gs_noil.shape == (2048, 2048)
+    assert np.array_equal(gs_il, gs_noil)
+    assert da_gs_il.shape == (2048, 2048)
+    assert da_gs_noil.shape == (2048, 2048)
+    assert np.array_equal(da_gs_il.compute(), da_gs_noil.compute())
+
+# PRIVATE_DIR = "tests/private_data"
+@pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
+def test_czi_tile_greyscale():
+    image_fp = os.path.join(PRIVATE_DIR, "czi_rgb.czi")
+    czi = CziRegImageReader(image_fp)
+    fsbd = czi.filtered_subblock_directory[5]
+    subblock = fsbd.data_segment()
+    tile = subblock.data(resize=False, order=0)
+    tile_gs = czi_tile_grayscale(tile)
+
+    assert tile.shape[:5] == tile_gs.shape[:5]
+    assert tile_gs.shape[-1] == 1
+    assert tile_gs.dtype == np.uint8
+
+@pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
+def test_CziRegImageReader_rgb():
+    image_fp = os.path.join(PRIVATE_DIR, "czi_rgb.czi")
+    czi = CziRegImageReader(image_fp)
+    gs_out = czi.sub_asarray_rgb(greyscale=True)
+    rgb_out = czi.sub_asarray_rgb(greyscale=False)
+
+    assert len(np.squeeze(gs_out).shape) == 2
+    assert len(np.squeeze(rgb_out).shape) == 3
+
+@pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
+def test_CziRegImageReader_mc():
+    image_fp = os.path.join(PRIVATE_DIR, "czi_4ch_16bit.czi")
+    czi = CziRegImageReader(image_fp)
+    mc_out = czi.sub_asarray(max_workers=1)
+    ch0_out = czi.sub_asarray(channel_idx=[0], max_workers=1)
+    ch1_out = czi.sub_asarray(channel_idx=[1], max_workers=1)
+    ch2_out = czi.sub_asarray(channel_idx=[2], max_workers=1)
+    ch3_out = czi.sub_asarray(channel_idx=[3], max_workers=1)
+    ch02_out = czi.sub_asarray(channel_idx=[0,2],max_workers=1)
+
+    assert np.squeeze(mc_out).shape == (4, 4305, 4194)
+    assert np.squeeze(ch0_out).shape == (4305,4194)
+    assert np.squeeze(ch1_out).shape == (4305,4194)
+    assert np.squeeze(ch1_out).shape == (4305,4194)
+    assert np.squeeze(ch2_out).shape == (4305,4194)
+    assert np.squeeze(ch3_out).shape == (4305,4194)
+    assert np.squeeze(ch02_out).shape == (2,4305,4194)
+    assert np.array_equal(np.squeeze(ch02_out), np.squeeze(mc_out)[[0,2],:,:])
+
+@pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
+def test_tf_get_largest_series():
+    image_fp_czi_mc = os.path.join(PRIVATE_DIR, "czi_4ch_16bit.ome.tiff")
+    image_fp_czi_rgb = os.path.join(PRIVATE_DIR, "czi_rgb.ome.tiff")
+    image_fp_bigtiff = os.path.join(PRIVATE_DIR, "huron_rgb.tif")
+    image_fp_scn = os.path.join(PRIVATE_DIR, "scn_rgb.scn")
+    assert tf_get_largest_series(image_fp_czi_mc) == 0
+    assert tf_get_largest_series(image_fp_czi_rgb) == 0
+    assert tf_get_largest_series(image_fp_bigtiff) == 0
+    assert tf_get_largest_series(image_fp_scn) == 1
+
+@pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
+def test_get_sitk_image_info():
+    image_fp_jpgrgb = os.path.join(PRIVATE_DIR, "testjpegrgb.jpg")
+    image_fp_pngrgb = os.path.join(PRIVATE_DIR, "testpngrgb.png")
+
+    assert np.array_equal(get_sitk_image_info(image_fp_jpgrgb)[0], [450,750,3])
+    assert get_sitk_image_info(image_fp_jpgrgb)[1] == np.uint8
+    assert np.array_equal(get_sitk_image_info(image_fp_pngrgb)[0], [450,750,3])
+    assert get_sitk_image_info(image_fp_pngrgb)[1] == np.uint8
+
+@pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
+def test_get_tifffile_info_private():
+    image_fp_bigtiff = os.path.join(PRIVATE_DIR, "huron_rgb.tif")
+    image_fp_scn = os.path.join(PRIVATE_DIR, "scn_rgb.scn")
+
+    assert np.array_equal(get_tifffile_info(image_fp_bigtiff)[0], [7662, 15778,     3])
+    assert get_tifffile_info(image_fp_bigtiff)[1] == np.uint8
+    assert np.array_equal(get_tifffile_info(image_fp_scn)[0], [11776, 18528,     3])
+    assert get_tifffile_info(image_fp_scn)[1] == np.uint8
+
+
+@pytest.mark.usefixtures(
+    "disk_im_gry_pyr",
+    "disk_im_mch_pyr",
+    "disk_im_rgb_pyr",
+)
+def test_get_tifffile_info_public(
+    disk_im_gry_pyr,
+    disk_im_mch_pyr,
+    disk_im_rgb_pyr,
+):
+
+    assert np.array_equal(get_tifffile_info(disk_im_rgb_pyr)[0], [2048,2048,3])
+    assert get_tifffile_info(disk_im_rgb_pyr)[1] == np.uint8
+
+    assert np.array_equal(get_tifffile_info(disk_im_mch_pyr)[0], [3,2048,2048])
+    assert get_tifffile_info(disk_im_mch_pyr)[1] == np.uint16
+
+    assert np.array_equal(get_tifffile_info(disk_im_gry_pyr)[0], [1,2048,2048])
+    assert get_tifffile_info(disk_im_gry_pyr)[1] == np.uint16

--- a/tests/test_reg_image.py
+++ b/tests/test_reg_image.py
@@ -9,64 +9,64 @@ import numpy as np
 def test_reg_image_loader_image_fp_mc_std_prepro(disk_im_mch):
     reg_image = reg_image_loader(str(disk_im_mch), 0.65)
     reg_image.read_reg_image()
-    assert reg_image.image.GetSize() == (2048, 2048)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetSize() == (2048, 2048)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
 
 
 @pytest.mark.usefixtures("disk_im_rgb")
 def test_reg_image_loader_image_fp_rgb_std_prepro(disk_im_rgb):
     reg_image = reg_image_loader(str(disk_im_rgb), 0.65)
     reg_image.read_reg_image()
-    assert reg_image.image.GetSize() == (2048, 2048)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetSize() == (2048, 2048)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
 
 
 @pytest.mark.usefixtures("disk_im_gry")
 def test_reg_image_loader_image_fp_gry_std_prepro(disk_im_gry):
     reg_image = reg_image_loader(str(disk_im_gry), 0.65)
     reg_image.read_reg_image()
-    assert reg_image.image.GetSize() == (2048, 2048)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetSize() == (2048, 2048)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
 
 
 @pytest.mark.usefixtures("im_mch_np")
 def test_reg_image_loader_image_np_mc_std_prepro(im_mch_np):
     reg_image = reg_image_loader(im_mch_np, 0.65)
     reg_image.read_reg_image()
-    assert reg_image.image.GetSize() == (2048, 2048)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
-    assert reg_image.image.GetDepth() == 0
+    assert reg_image.reg_image.GetSize() == (2048, 2048)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetDepth() == 0
 
 
 @pytest.mark.usefixtures("im_rgb_np")
 def test_reg_image_loader_image_np_rgb_std_prepro(im_rgb_np):
     reg_image = reg_image_loader(im_rgb_np, 0.65)
     reg_image.read_reg_image()
-    assert reg_image.image.GetSize() == (2048, 2048)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSize() == (2048, 2048)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
 
 
 @pytest.mark.usefixtures("im_gry_np")
 def test_reg_image_loader_image_np_gry_std_prepro(im_gry_np):
     reg_image = reg_image_loader(im_gry_np, 0.65)
     reg_image.read_reg_image()
-    assert reg_image.image.GetSize() == (2048, 2048)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSize() == (2048, 2048)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
 
 
 @pytest.mark.usefixtures("im_mch_np")
 def test_reg_image_loader_image_np_mc_std_prepro_rot(im_mch_np):
     reg_image = reg_image_loader(im_mch_np, 0.65, preprocessing={"rot_cc": 90})
     reg_image.read_reg_image()
-    assert reg_image.image.GetSize() == (2048, 2048)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
-    assert reg_image.image.GetDepth() == 0
+    assert reg_image.reg_image.GetSize() == (2048, 2048)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetDepth() == 0
     assert reg_image.pre_reg_transforms is not None
     assert len(reg_image.pre_reg_transforms) == 1
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
 
 
 @pytest.mark.usefixtures("im_rgb_np")
@@ -74,11 +74,11 @@ def test_reg_image_loader_image_np_rgb_std_prepro_rot(im_rgb_np):
     reg_image = reg_image_loader(im_rgb_np, 0.65, preprocessing={"rot_cc": 90})
     reg_image.read_reg_image()
 
-    assert reg_image.image.GetSize() == (2048, 2048)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSize() == (2048, 2048)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
     assert reg_image.pre_reg_transforms is not None
     assert len(reg_image.pre_reg_transforms) == 1
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
 
 
 @pytest.mark.usefixtures("im_gry_np")
@@ -86,11 +86,11 @@ def test_reg_image_loader_image_np_gry_std_prepro_rot(im_gry_np):
     reg_image = reg_image_loader(im_gry_np, 0.65, preprocessing={"rot_cc": 90})
     reg_image.read_reg_image()
 
-    assert reg_image.image.GetSize() == (2048, 2048)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSize() == (2048, 2048)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
     assert reg_image.pre_reg_transforms is not None
     assert len(reg_image.pre_reg_transforms) == 1
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
 
 
 @pytest.mark.usefixtures("im_mch_np")
@@ -98,23 +98,23 @@ def test_reg_image_loader_image_np_mc_std_prepro_fliph(im_mch_np):
     reg_image = reg_image_loader(im_mch_np, 0.65, preprocessing={"flip": "h"})
     reg_image.read_reg_image()
 
-    assert reg_image.image.GetSize() == (2048, 2048)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
-    assert reg_image.image.GetDepth() == 0
+    assert reg_image.reg_image.GetSize() == (2048, 2048)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetDepth() == 0
     assert reg_image.pre_reg_transforms is not None
     assert len(reg_image.pre_reg_transforms) == 1
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
 
 
 @pytest.mark.usefixtures("im_rgb_np")
 def test_reg_image_loader_image_np_rgb_std_prepro_fliph(im_rgb_np):
     reg_image = reg_image_loader(im_rgb_np, 0.65, preprocessing={"flip": "h"})
     reg_image.read_reg_image()
-    assert reg_image.image.GetSize() == (2048, 2048)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSize() == (2048, 2048)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
     assert reg_image.pre_reg_transforms is not None
     assert len(reg_image.pre_reg_transforms) == 1
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
 
 
 @pytest.mark.usefixtures("im_gry_np")
@@ -122,11 +122,11 @@ def test_reg_image_loader_image_np_gry_std_prepro_fliph(im_gry_np):
     reg_image = reg_image_loader(im_gry_np, 0.65, preprocessing={"flip": "h"})
     reg_image.read_reg_image()
 
-    assert reg_image.image.GetSize() == (2048, 2048)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSize() == (2048, 2048)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
     assert reg_image.pre_reg_transforms is not None
     assert len(reg_image.pre_reg_transforms) == 1
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
 
 
 @pytest.mark.usefixtures("im_mch_np")
@@ -134,12 +134,12 @@ def test_reg_image_loader_image_np_mc_std_prepro_flipv(im_mch_np):
     reg_image = reg_image_loader(im_mch_np, 0.65, preprocessing={"flip": "v"})
     reg_image.read_reg_image()
 
-    assert reg_image.image.GetSize() == (2048, 2048)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
-    assert reg_image.image.GetDepth() == 0
+    assert reg_image.reg_image.GetSize() == (2048, 2048)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetDepth() == 0
     assert reg_image.pre_reg_transforms is not None
     assert len(reg_image.pre_reg_transforms) == 1
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
 
 
 @pytest.mark.usefixtures("im_rgb_np")
@@ -147,11 +147,11 @@ def test_reg_image_loader_image_np_rgb_std_prepro_flipv(im_rgb_np):
     reg_image = reg_image_loader(im_rgb_np, 0.65, preprocessing={"flip": "v"})
     reg_image.read_reg_image()
 
-    assert reg_image.image.GetSize() == (2048, 2048)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSize() == (2048, 2048)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
     assert reg_image.pre_reg_transforms is not None
     assert len(reg_image.pre_reg_transforms) == 1
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
 
 
 @pytest.mark.usefixtures("im_gry_np")
@@ -159,11 +159,11 @@ def test_reg_image_loader_image_np_gry_std_prepro_flipv(im_gry_np):
     reg_image = reg_image_loader(im_gry_np, 0.65, preprocessing={"flip": "v"})
     reg_image.read_reg_image()
 
-    assert reg_image.image.GetSize() == (2048, 2048)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSize() == (2048, 2048)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
     assert reg_image.pre_reg_transforms is not None
     assert len(reg_image.pre_reg_transforms) == 1
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
 
 
 @pytest.mark.usefixtures("im_mch_np")
@@ -173,11 +173,11 @@ def test_reg_image_loader_image_np_mc_std_prepro_rot_flipv(im_mch_np):
     )
     reg_image.read_reg_image()
 
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
-    assert reg_image.image.GetDepth() == 0
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetDepth() == 0
     assert reg_image.pre_reg_transforms is not None
     assert len(reg_image.pre_reg_transforms) == 2
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
 
 
 @pytest.mark.usefixtures("im_gry_np")
@@ -185,11 +185,11 @@ def test_reg_image_loader_image_np_gry_std_prepro_flipv(im_gry_np):
     reg_image = reg_image_loader(im_gry_np, 0.65, preprocessing={"flip": "v"})
     reg_image.read_reg_image()
 
-    assert reg_image.image.GetSize() == (2048, 2048)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSize() == (2048, 2048)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
     assert reg_image.pre_reg_transforms is not None
     assert len(reg_image.pre_reg_transforms) == 1
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
 
 
 @pytest.mark.usefixtures("im_gry_np", "mask_np")
@@ -247,19 +247,19 @@ def test_reg_image_loader_downsampling(im_gry_np, mask_np):
     )
     reg_image.read_reg_image()
 
-    assert reg_image.image.GetSize() == (1024, 1024)
+    assert reg_image.reg_image.GetSize() == (1024, 1024)
     assert reg_image.mask.GetSize() == (1024, 1024)
     assert reg_image.mask.GetSpacing() == (2, 2)
-    assert reg_image.image.GetSpacing() == (2, 2)
+    assert reg_image.reg_image.GetSpacing() == (2, 2)
 
 
 @pytest.mark.usefixtures("im_gry_np", "mask_np")
 def test_reg_image_loader_to_itk(im_gry_np, mask_np):
     reg_image = reg_image_loader(im_gry_np, 0.65, mask=mask_np)
     reg_image.read_reg_image()
-    reg_image.sitk_to_itk(cast_to_float32=True)
-    assert isinstance(reg_image.image, itk.Image) is True
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
+    reg_image.reg_image_sitk_to_itk(cast_to_float32=True)
+    assert isinstance(reg_image.reg_image, itk.Image) is True
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
     assert isinstance(reg_image.mask, itk.Image) is True
     assert reg_image.mask.GetSpacing() == (0.65, 0.65)
 
@@ -268,9 +268,9 @@ def test_reg_image_loader_to_itk(im_gry_np, mask_np):
 def test_reg_image_loader_to_itk(im_gry_np, mask_np):
     reg_image = reg_image_loader(im_gry_np, 0.65, mask=mask_np)
     reg_image.read_reg_image()
-    reg_image.sitk_to_itk(cast_to_float32=True)
-    assert isinstance(reg_image.image, itk.Image) is True
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
+    reg_image.reg_image_sitk_to_itk(cast_to_float32=True)
+    assert isinstance(reg_image.reg_image, itk.Image) is True
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
     assert isinstance(reg_image.mask, itk.Image) is True
     assert reg_image.mask.GetSpacing() == (0.65, 0.65)
 
@@ -283,8 +283,8 @@ def test_reg_image_loader_dask_rgb(dask_im_rgb_np):
     assert reg_image.im_dims[-1] == 3
     assert reg_image.is_rgb
     assert reg_image.n_ch == 3
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
 
 
 @pytest.mark.usefixtures("dask_im_gry_np")
@@ -295,8 +295,8 @@ def test_reg_image_loader_dask_gry(dask_im_gry_np):
     assert reg_image.im_dims[0] == 1
     assert reg_image.is_rgb is False
     assert reg_image.n_ch == 1
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
 
 
 @pytest.mark.usefixtures("dask_im_mch_np")
@@ -307,8 +307,8 @@ def test_reg_image_loader_dask_mch(dask_im_mch_np):
     assert reg_image.im_dims[0] == 3
     assert reg_image.is_rgb is False
     assert reg_image.n_ch == 3
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
 
 
 @pytest.mark.usefixtures("zarr_im_rgb_np")
@@ -319,8 +319,8 @@ def test_reg_image_loader_zarr_rgb(zarr_im_rgb_np):
     assert reg_image.im_dims[-1] == 3
     assert reg_image.is_rgb
     assert reg_image.n_ch == 3
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
 
 
 @pytest.mark.usefixtures("zarr_im_gry_np")
@@ -331,8 +331,8 @@ def test_reg_image_loader_zarr_gry(zarr_im_gry_np):
     assert reg_image.im_dims[0] == 1
     assert reg_image.is_rgb is False
     assert reg_image.n_ch == 1
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1
 
 
 @pytest.mark.usefixtures("zarr_im_mch_np")
@@ -343,5 +343,5 @@ def test_reg_image_loader_zarr_mch(zarr_im_mch_np):
     assert reg_image.im_dims[0] == 3
     assert reg_image.is_rgb is False
     assert reg_image.n_ch == 3
-    assert reg_image.image.GetSpacing() == (0.65, 0.65)
-    assert reg_image.image.GetNumberOfComponentsPerPixel() == 1
+    assert reg_image.reg_image.GetSpacing() == (0.65, 0.65)
+    assert reg_image.reg_image.GetNumberOfComponentsPerPixel() == 1

--- a/wsireg/__init__.py
+++ b/wsireg/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Nathan Heath Patterson"""
 __email__ = 'heath.patterson@vanderbilt.edu'
-__version__ = '0.2.1'
+__version__ = '0.3.0'

--- a/wsireg/reg_images/loader.py
+++ b/wsireg/reg_images/loader.py
@@ -27,56 +27,59 @@ def reg_image_loader(
         return NumpyRegImage(
             image,
             image_res,
-            mask,
-            pre_reg_transforms,
-            preprocessing,
-            channel_names,
-            channel_colors,
+            mask=mask,
+            pre_reg_transforms=pre_reg_transforms,
+            preprocessing=preprocessing,
+            channel_names=channel_names,
+            channel_colors=channel_colors,
+            image_filepath=None,
         )
 
     image_ext = Path(image).suffix
     if image_ext in TIFFFILE_EXTS:
         if TiffFile(image).is_ome:
-            image = ome_tifffile_to_arraylike(image)
+            image, image_filepath = ome_tifffile_to_arraylike(image)
             reg_image = NumpyRegImage(
                 image,
                 image_res,
-                mask,
-                pre_reg_transforms,
-                preprocessing,
-                channel_names,
-                channel_colors,
+                mask=mask,
+                pre_reg_transforms=pre_reg_transforms,
+                preprocessing=preprocessing,
+                channel_names=channel_names,
+                channel_colors=channel_colors,
+                image_filepath=image_filepath,
             )
         else:
-            image = tifffile_to_arraylike(image)
+            image, image_filepath = tifffile_to_arraylike(image)
             reg_image = NumpyRegImage(
                 image,
                 image_res,
-                mask,
-                pre_reg_transforms,
-                preprocessing,
-                channel_names,
-                channel_colors,
+                mask=mask,
+                pre_reg_transforms=pre_reg_transforms,
+                preprocessing=preprocessing,
+                channel_names=channel_names,
+                channel_colors=channel_colors,
+                image_filepath=image_filepath,
             )
     elif image_ext == ".czi":
         reg_image = CziRegImage(
             image,
             image_res,
-            mask,
-            pre_reg_transforms,
-            preprocessing,
-            channel_names,
-            channel_colors,
+            mask=mask,
+            pre_reg_transforms=pre_reg_transforms,
+            preprocessing=preprocessing,
+            channel_names=channel_names,
+            channel_colors=channel_colors,
         )
     else:
         reg_image = SitkRegImage(
             image,
             image_res,
-            mask,
-            pre_reg_transforms,
-            preprocessing,
-            channel_names,
-            channel_colors,
+            mask=mask,
+            pre_reg_transforms=pre_reg_transforms,
+            preprocessing=preprocessing,
+            channel_names=channel_names,
+            channel_colors=channel_colors,
         )
 
     return reg_image

--- a/wsireg/reg_images/np_reg_image.py
+++ b/wsireg/reg_images/np_reg_image.py
@@ -21,13 +21,13 @@ class NumpyRegImage(RegImage):
         preprocessing=None,
         channel_names=None,
         channel_colors=None,
+        image_filepath=None,
     ):
-        self.image_filepath = "numpy"
+        self.image_filepath = image_filepath
         self.image_res = image_res
         self.reader = "numpy"
 
         self.image = ensure_dask_array(image)
-
         self.image = da.squeeze(self.image)
 
         (
@@ -40,6 +40,7 @@ class NumpyRegImage(RegImage):
 
         self.n_ch = self.im_dims[2] if self.is_rgb else self.im_dims[0]
 
+        self.reg_image = None
         self.mask = self.read_mask(mask)
 
         if preprocessing is None:
@@ -63,29 +64,29 @@ class NumpyRegImage(RegImage):
 
     def read_reg_image(self):
 
-        image = read_preprocess_array(
+        reg_image = read_preprocess_array(
             self.image, preprocessing=self.preprocessing, force_rgb=self.is_rgb
         )
 
         if (
             self.preprocessing is not None
             and self.preprocessing.get('as_uint8') is True
-            and image.GetPixelID() != sitk.sitkUInt8
+            and reg_image.GetPixelID() != sitk.sitkUInt8
         ):
-            image = sitk.RescaleIntensity(image)
-            image = sitk.Cast(image, sitk.sitkUInt8)
+            reg_image = sitk.RescaleIntensity(reg_image)
+            reg_image = sitk.Cast(reg_image, sitk.sitkUInt8)
 
-        image, spatial_preprocessing = self.preprocess_reg_image_intensity(
-            image, self.preprocessing
+        reg_image, spatial_preprocessing = self.preprocess_reg_image_intensity(
+            reg_image, self.preprocessing
         )
 
-        if image.GetDepth() >= 1:
+        if reg_image.GetDepth() >= 1:
             raise ValueError(
                 "preprocessing did not result in a single image plane\n"
                 "multi-channel or 3D image return"
             )
 
-        if image.GetNumberOfComponentsPerPixel() > 1:
+        if reg_image.GetNumberOfComponentsPerPixel() > 1:
             raise ValueError(
                 "preprocessing did not result in a single image plane\n"
                 "multi-component / RGB(A) image returned"
@@ -96,13 +97,13 @@ class NumpyRegImage(RegImage):
             or self.pre_reg_transforms is not None
         ):
             (
-                self.image,
+                self.reg_image,
                 self.pre_reg_transforms,
             ) = self.preprocess_reg_image_spatial(
-                image, spatial_preprocessing, self.pre_reg_transforms
+                reg_image, spatial_preprocessing, self.pre_reg_transforms
             )
         else:
-            self.image = image
+            self.reg_image = reg_image
             self.pre_reg_transforms = None
 
     def read_single_channel(self, channel_idx: int):

--- a/wsireg/reg_images/reg_image.py
+++ b/wsireg/reg_images/reg_image.py
@@ -49,6 +49,8 @@ class RegImage:
     """
 
     def __init__(self):
+        self.image = None
+        self.reg_image = None
         self.original_size_transform = None
         return
 
@@ -233,9 +235,9 @@ class RegImage:
             self.mask = None
         return image, transforms
 
-    def sitk_to_itk(self, cast_to_float32=True):
-        self.image = sitk_image_to_itk_image(
-            self.image, cast_to_float32=cast_to_float32
+    def reg_image_sitk_to_itk(self, cast_to_float32=True):
+        self.reg_image = sitk_image_to_itk_image(
+            self.reg_image, cast_to_float32=cast_to_float32
         )
         if self.mask is not None:
             self.mask = sitk_image_to_itk_image(

--- a/wsireg/reg_images/sitk_reg_image.py
+++ b/wsireg/reg_images/sitk_reg_image.py
@@ -6,13 +6,14 @@ from wsireg.utils.im_utils import (
     guess_rgb,
     get_sitk_image_info,
     sitk_vect_to_gs,
+    ensure_dask_array,
 )
 
 
 class SitkRegImage(RegImage):
     def __init__(
         self,
-        image_fp,
+        image,
         image_res,
         mask=None,
         pre_reg_transforms=None,
@@ -20,9 +21,10 @@ class SitkRegImage(RegImage):
         channel_names=None,
         channel_colors=None,
     ):
-        self.image_filepath = image_fp
+        self.image_filepath = image
         self.image_res = image_res
         self.image = None
+
         self.reader = "sitk"
 
         (
@@ -35,6 +37,7 @@ class SitkRegImage(RegImage):
 
         self.n_ch = self.im_dims[2] if self.is_rgb else self.im_dims[0]
 
+        self.reg_image = None
         self.mask = self.read_mask(mask)
 
         if preprocessing is None:
@@ -56,39 +59,41 @@ class SitkRegImage(RegImage):
         return im_dims, im_dtype
 
     def read_reg_image(self):
-        image = sitk.ReadImage(self.image_filepath)
+        reg_image = sitk.ReadImage(self.image_filepath)
 
-        if image.GetNumberOfComponentsPerPixel() >= 3:
+        if reg_image.GetNumberOfComponentsPerPixel() >= 3:
             if self.preprocessing is not None:
-                image = sitk_vect_to_gs(image)
+                reg_image = sitk_vect_to_gs(reg_image)
 
         if (
             self.preprocessing.get("as_uint8") is True
-            and image.GetPixelID() != 1
+            and reg_image.GetPixelID() != 1
         ):
-            image = sitk.Cast(sitk.RescaleIntensity(image), sitk.sitkUInt8)
+            reg_image = sitk.Cast(
+                sitk.RescaleIntensity(reg_image), sitk.sitkUInt8
+            )
 
         if (
             self.preprocessing.get("ch_indices") is not None
-            and image.GetDepth() > 0
+            and reg_image.GetDepth() > 0
         ):
             chs = np.asarray(self.preprocessing.get('ch_indices'))
-            image = image[:, :, chs]
+            reg_image = reg_image[:, :, chs]
 
-        image, spatial_preprocessing = self.preprocess_reg_image_intensity(
-            image, self.preprocessing
+        reg_image, spatial_preprocessing = self.preprocess_reg_image_intensity(
+            reg_image, self.preprocessing
         )
 
-        if image.GetDepth() >= 1:
+        if reg_image.GetDepth() >= 1:
             raise ValueError(
-                "preprocessing did not result in a single image plane\n"
-                "multi-channel or 3D image return"
+                "preprocessing did not result in a single reg_image plane\n"
+                "multi-channel or 3D reg_image return"
             )
 
-        if image.GetNumberOfComponentsPerPixel() > 1:
+        if reg_image.GetNumberOfComponentsPerPixel() > 1:
             raise ValueError(
-                "preprocessing did not result in a single image plane\n"
-                "multi-component / RGB(A) image returned"
+                "preprocessing did not result in a single reg_image plane\n"
+                "multi-component / RGB(A) reg_image returned"
             )
 
         if (
@@ -96,11 +101,16 @@ class SitkRegImage(RegImage):
             or self.pre_reg_transforms is not None
         ):
             (
-                self.image,
+                self.reg_image,
                 self.pre_reg_transforms,
             ) = self.preprocess_reg_image_spatial(
-                image, spatial_preprocessing, self.pre_reg_transforms
+                reg_image, spatial_preprocessing, self.pre_reg_transforms
             )
         else:
-            self.image = image
+            self.reg_image = reg_image
             self.pre_reg_transforms = None
+
+    def read_full_image(self):
+        self.image = ensure_dask_array(
+            sitk.GetArrayFromImage(sitk.ReadImage(self.image_filepath))
+        )

--- a/wsireg/utils/reg_utils.py
+++ b/wsireg/utils/reg_utils.py
@@ -190,11 +190,12 @@ def register_2d_images_itkelx(
         source_image.image = matcher.Execute(
             source_image.image, target_image.image
         )
-    source_image.sitk_to_itk()
-    target_image.sitk_to_itk()
+
+    source_image.reg_image_sitk_to_itk()
+    target_image.reg_image_sitk_to_itk()
 
     selx = itk.ElastixRegistrationMethod.New(
-        source_image.image, target_image.image
+        source_image.reg_image, target_image.reg_image
     )
 
     # Set additional options
@@ -207,8 +208,8 @@ def register_2d_images_itkelx(
     if target_image.mask is not None:
         selx.SetFixedMask(target_image.mask)
 
-    selx.SetMovingImage(source_image.image)
-    selx.SetFixedImage(target_image.image)
+    selx.SetMovingImage(source_image.reg_image)
+    selx.SetFixedImage(target_image.reg_image)
 
     parameter_object_registration = itk.ParameterObject.New()
     for idx, reg_param in enumerate(reg_params):

--- a/wsireg/writers/ome_tiff_writer.py
+++ b/wsireg/writers/ome_tiff_writer.py
@@ -128,6 +128,8 @@ class OmeTiffWriter:
 
         print(f"saving to {output_file_name}")
         with TiffWriter(output_file_name, bigtiff=True) as tif:
+            if self.reg_image.reader == "sitk":
+                self.reg_image.read_full_image()
             for channel_idx in range(self.reg_image.n_ch):
                 print(f"transforming : {channel_idx}")
                 if self.reg_image.reader != "sitk":
@@ -137,16 +139,6 @@ class OmeTiffWriter:
                     image.SetSpacing(
                         (self.reg_image.image_res, self.reg_image.image_res)
                     )
-                else:
-                    full_image = sitk.ReadImage(self.reg_image.image_filepath)
-                    if self.reg_image.is_rgb:
-                        image = sitk.VectorIndexSelectionCast(
-                            full_image, channel_idx
-                        )
-                    elif len(full_image.GetSize()) > 2:
-                        image = full_image[:, :, channel_idx]
-                    else:
-                        image = full_image
 
                 if composite_transform is not None:
                     image = transform_plane(

--- a/wsireg/wsireg2d.py
+++ b/wsireg/wsireg2d.py
@@ -498,7 +498,7 @@ class WsiReg2D(object):
             / "{}_orig_size_tform.json".format(cache_im_fp.stem)
         )
         if cache_im_fp.is_file() is False:
-            sitk.WriteImage(reg_image.image, str(cache_im_fp), True)
+            sitk.WriteImage(reg_image.reg_image, str(cache_im_fp), True)
 
         if reg_image.mask is not None:
             cache_mask_im_fp = self.image_cache / "{}_prepro_mask.tiff".format(
@@ -652,6 +652,7 @@ class WsiReg2D(object):
 
                 src_reg_image.read_reg_image()
                 tgt_reg_image.read_reg_image()
+
                 if (
                     tgt_original_size_transform is None
                     and tgt_reg_image.original_size_transform is not None


### PR DESCRIPTION
This PR updates the RegImage subclasses and loader to be more explicit about image life. This is on the road to updating the WsiReg2D API to be much more accessible. 