### PR TITLE
Add writing merged and unmerged image versions optionally

### DIFF
--- a/tests/fixtures/im_fixtures.py
+++ b/tests/fixtures/im_fixtures.py
@@ -73,11 +73,13 @@ def disk_im_mch(tmpdir_factory, im_mch_np):
     imwrite(out_im, im_mch_np, tile=(256, 256))
     return out_im
 
+
 @pytest.fixture
 def disk_im_mch_notile(tmpdir_factory, im_mch_np):
     out_im = tmpdir_factory.mktemp("image").join("image_fp_mch_nt.tiff")
-    imwrite(out_im, im_mch_np, photometric="MINISBLACK", tile=(256,256))
+    imwrite(out_im, im_mch_np, photometric="MINISBLACK", tile=(256, 256))
     return out_im
+
 
 @pytest.fixture
 def disk_im_rgb(tmpdir_factory, im_rgb_np):

--- a/tests/test_im_utils.py
+++ b/tests/test_im_utils.py
@@ -17,7 +17,7 @@ from wsireg.utils.im_utils import (
     CziRegImageReader,
     tf_get_largest_series,
     get_sitk_image_info,
-    get_tifffile_info
+    get_tifffile_info,
 )
 
 # private data logic borrowed from https://github.com/cgohlke/tifffile/tests/test_tifffile.py
@@ -341,6 +341,7 @@ def test_greyscale():
     assert da_gs_noil.shape == (2048, 2048)
     assert np.array_equal(da_gs_il.compute(), da_gs_noil.compute())
 
+
 # PRIVATE_DIR = "tests/private_data"
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
 def test_czi_tile_greyscale():
@@ -355,6 +356,7 @@ def test_czi_tile_greyscale():
     assert tile_gs.shape[-1] == 1
     assert tile_gs.dtype == np.uint8
 
+
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
 def test_CziRegImageReader_rgb():
     image_fp = os.path.join(PRIVATE_DIR, "czi_rgb.czi")
@@ -365,6 +367,7 @@ def test_CziRegImageReader_rgb():
     assert len(np.squeeze(gs_out).shape) == 2
     assert len(np.squeeze(rgb_out).shape) == 3
 
+
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
 def test_CziRegImageReader_mc():
     image_fp = os.path.join(PRIVATE_DIR, "czi_4ch_16bit.czi")
@@ -374,16 +377,19 @@ def test_CziRegImageReader_mc():
     ch1_out = czi.sub_asarray(channel_idx=[1], max_workers=1)
     ch2_out = czi.sub_asarray(channel_idx=[2], max_workers=1)
     ch3_out = czi.sub_asarray(channel_idx=[3], max_workers=1)
-    ch02_out = czi.sub_asarray(channel_idx=[0,2],max_workers=1)
+    ch02_out = czi.sub_asarray(channel_idx=[0, 2], max_workers=1)
 
     assert np.squeeze(mc_out).shape == (4, 4305, 4194)
-    assert np.squeeze(ch0_out).shape == (4305,4194)
-    assert np.squeeze(ch1_out).shape == (4305,4194)
-    assert np.squeeze(ch1_out).shape == (4305,4194)
-    assert np.squeeze(ch2_out).shape == (4305,4194)
-    assert np.squeeze(ch3_out).shape == (4305,4194)
-    assert np.squeeze(ch02_out).shape == (2,4305,4194)
-    assert np.array_equal(np.squeeze(ch02_out), np.squeeze(mc_out)[[0,2],:,:])
+    assert np.squeeze(ch0_out).shape == (4305, 4194)
+    assert np.squeeze(ch1_out).shape == (4305, 4194)
+    assert np.squeeze(ch1_out).shape == (4305, 4194)
+    assert np.squeeze(ch2_out).shape == (4305, 4194)
+    assert np.squeeze(ch3_out).shape == (4305, 4194)
+    assert np.squeeze(ch02_out).shape == (2, 4305, 4194)
+    assert np.array_equal(
+        np.squeeze(ch02_out), np.squeeze(mc_out)[[0, 2], :, :]
+    )
+
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
 def test_tf_get_largest_series():
@@ -396,24 +402,34 @@ def test_tf_get_largest_series():
     assert tf_get_largest_series(image_fp_bigtiff) == 0
     assert tf_get_largest_series(image_fp_scn) == 1
 
+
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
 def test_get_sitk_image_info():
     image_fp_jpgrgb = os.path.join(PRIVATE_DIR, "testjpegrgb.jpg")
     image_fp_pngrgb = os.path.join(PRIVATE_DIR, "testpngrgb.png")
 
-    assert np.array_equal(get_sitk_image_info(image_fp_jpgrgb)[0], [450,750,3])
+    assert np.array_equal(
+        get_sitk_image_info(image_fp_jpgrgb)[0], [450, 750, 3]
+    )
     assert get_sitk_image_info(image_fp_jpgrgb)[1] == np.uint8
-    assert np.array_equal(get_sitk_image_info(image_fp_pngrgb)[0], [450,750,3])
+    assert np.array_equal(
+        get_sitk_image_info(image_fp_pngrgb)[0], [450, 750, 3]
+    )
     assert get_sitk_image_info(image_fp_pngrgb)[1] == np.uint8
+
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
 def test_get_tifffile_info_private():
     image_fp_bigtiff = os.path.join(PRIVATE_DIR, "huron_rgb.tif")
     image_fp_scn = os.path.join(PRIVATE_DIR, "scn_rgb.scn")
 
-    assert np.array_equal(get_tifffile_info(image_fp_bigtiff)[0], [7662, 15778,     3])
+    assert np.array_equal(
+        get_tifffile_info(image_fp_bigtiff)[0], [7662, 15778, 3]
+    )
     assert get_tifffile_info(image_fp_bigtiff)[1] == np.uint8
-    assert np.array_equal(get_tifffile_info(image_fp_scn)[0], [11776, 18528,     3])
+    assert np.array_equal(
+        get_tifffile_info(image_fp_scn)[0], [11776, 18528, 3]
+    )
     assert get_tifffile_info(image_fp_scn)[1] == np.uint8
 
 
@@ -428,11 +444,17 @@ def test_get_tifffile_info_public(
     disk_im_rgb_pyr,
 ):
 
-    assert np.array_equal(get_tifffile_info(disk_im_rgb_pyr)[0], [2048,2048,3])
+    assert np.array_equal(
+        get_tifffile_info(disk_im_rgb_pyr)[0], [2048, 2048, 3]
+    )
     assert get_tifffile_info(disk_im_rgb_pyr)[1] == np.uint8
 
-    assert np.array_equal(get_tifffile_info(disk_im_mch_pyr)[0], [3,2048,2048])
+    assert np.array_equal(
+        get_tifffile_info(disk_im_mch_pyr)[0], [3, 2048, 2048]
+    )
     assert get_tifffile_info(disk_im_mch_pyr)[1] == np.uint16
 
-    assert np.array_equal(get_tifffile_info(disk_im_gry_pyr)[0], [1,2048,2048])
+    assert np.array_equal(
+        get_tifffile_info(disk_im_gry_pyr)[0], [1, 2048, 2048]
+    )
     assert get_tifffile_info(disk_im_gry_pyr)[1] == np.uint16

--- a/tests/test_wsireg.py
+++ b/tests/test_wsireg.py
@@ -360,3 +360,53 @@ def test_wsireg_run_reg_wmerge(data_out_dir, disk_im_gry):
     merged_im = reg_image_loader(im_fps[0], 0.65)
     assert Path(im_fps[0]).exists() is True
     assert merged_im.im_dims == (2, 2048, 2048)
+
+
+def test_wsireg_run_reg_wmerge_and_indiv(data_out_dir, disk_im_gry):
+    wsi_reg = WsiReg2D("test_proj-merge-and-unmerge", str(data_out_dir))
+    img_fp1 = str(disk_im_gry)
+
+    wsi_reg.add_modality(
+        "mod1",
+        img_fp1,
+        0.65,
+        channel_names=["test"],
+        channel_colors=["red"],
+    )
+
+    wsi_reg.add_modality(
+        "mod2",
+        img_fp1,
+        0.65,
+        channel_names=["test"],
+        channel_colors=["red"],
+    )
+
+    wsi_reg.add_modality(
+        "mod3",
+        img_fp1,
+        0.65,
+        channel_names=["test"],
+        channel_colors=["red"],
+    )
+
+    wsi_reg.add_reg_path(
+        "mod2", "mod1", reg_params=["rigid_test", "affine_test"]
+    )
+    wsi_reg.add_reg_path(
+        "mod3", "mod1", reg_params=["rigid_test", "affine_test"]
+    )
+    wsi_reg.add_merge_modalities("test_merge", ["mod1", "mod2"])
+    wsi_reg.register_images()
+    im_fps = wsi_reg.transform_images(
+        remove_merged=False, transform_non_reg=True
+    )
+
+    merged_im = reg_image_loader(im_fps[-2], 0.65)
+
+    assert len(im_fps) == 4
+    assert Path(im_fps[0]).exists() is True
+    assert Path(im_fps[1]).exists() is True
+    assert Path(im_fps[2]).exists() is True
+    assert Path(im_fps[3]).exists() is True
+    assert merged_im.im_dims == (2, 2048, 2048)

--- a/wsireg/reg_images/reg_image.py
+++ b/wsireg/reg_images/reg_image.py
@@ -16,9 +16,6 @@ from wsireg.utils.tform_utils import (
     gen_rig_to_original,
     prepare_wsireg_transform_data,
 )
-from wsireg.utils.itk_im_conversions import (
-    sitk_image_to_itk_image,
-)
 from wsireg.writers.ome_tiff_writer import OmeTiffWriter
 
 
@@ -201,9 +198,7 @@ class RegImage:
                         composite_transform,
                         _,
                         final_tform,
-                    ) = prepare_wsireg_transform_data(
-                        {"initial": [rot_tform]}
-                    )
+                    ) = prepare_wsireg_transform_data({"initial": [rot_tform]})
 
                     image = transform_plane(
                         image, final_tform, composite_transform
@@ -286,14 +281,13 @@ class RegImage:
         else:
             self.reg_image = sitk.GetArrayFromImage(self.reg_image)
 
-        self.reg_image = itk.GetImageFromArray(self.reg_image, is_vector=is_vector)
+        self.reg_image = itk.GetImageFromArray(
+            self.reg_image, is_vector=is_vector
+        )
         self.reg_image.SetOrigin(origin)
         self.reg_image.SetSpacing(spacing)
 
         if self.mask is not None:
-            self.mask = sitk_image_to_itk_image(
-                self.mask, cast_to_float32=False
-            )
             origin = self.mask.GetOrigin()
             spacing = self.mask.GetSpacing()
             # direction = image.GetDirection()

--- a/wsireg/reg_images/reg_image.py
+++ b/wsireg/reg_images/reg_image.py
@@ -276,13 +276,38 @@ class RegImage:
         return image, transforms
 
     def reg_image_sitk_to_itk(self, cast_to_float32=True):
-        self.reg_image = sitk_image_to_itk_image(
-            self.reg_image, cast_to_float32=cast_to_float32
-        )
+        origin = self.reg_image.GetOrigin()
+        spacing = self.reg_image.GetSpacing()
+        # direction = image.GetDirection()
+        is_vector = self.reg_image.GetNumberOfComponentsPerPixel() > 1
+        if cast_to_float32 is True:
+            self.reg_image = sitk.Cast(self.reg_image, sitk.sitkFloat32)
+            self.reg_image = sitk.GetArrayFromImage(self.reg_image)
+        else:
+            self.reg_image = sitk.GetArrayFromImage(self.reg_image)
+
+        self.reg_image = itk.GetImageFromArray(self.reg_image, is_vector=is_vector)
+        self.reg_image.SetOrigin(origin)
+        self.reg_image.SetSpacing(spacing)
+
         if self.mask is not None:
             self.mask = sitk_image_to_itk_image(
                 self.mask, cast_to_float32=False
             )
+            origin = self.mask.GetOrigin()
+            spacing = self.mask.GetSpacing()
+            # direction = image.GetDirection()
+            is_vector = self.mask.GetNumberOfComponentsPerPixel() > 1
+            if cast_to_float32 is True:
+                self.mask = sitk.Cast(self.mask, sitk.sitkFloat32)
+                self.mask = sitk.GetArrayFromImage(self.mask)
+            else:
+                self.mask = sitk.GetArrayFromImage(self.mask)
+
+            self.mask = itk.GetImageFromArray(self.mask, is_vector=is_vector)
+            self.mask.SetOrigin(origin)
+            self.mask.SetSpacing(spacing)
+
             mask_im_type = itk.Image[itk.UC, 2]
             self.mask = itk.binary_threshold_image_filter(
                 self.mask,

--- a/wsireg/utils/itk_im_conversions.py
+++ b/wsireg/utils/itk_im_conversions.py
@@ -1,6 +1,5 @@
 import SimpleITK as sitk
 import itk
-import numpy as np
 
 
 def itk_image_to_sitk_image(image):

--- a/wsireg/utils/itk_im_conversions.py
+++ b/wsireg/utils/itk_im_conversions.py
@@ -23,7 +23,8 @@ def sitk_image_to_itk_image(image, cast_to_float32=False):
     # direction = image.GetDirection()
     is_vector = image.GetNumberOfComponentsPerPixel() > 1
     if cast_to_float32 is True:
-        image = sitk.GetArrayFromImage(image).astype(np.float32)
+        image = sitk.Cast(image, sitk.sitkFloat32)
+        image = sitk.GetArrayFromImage(image)
     else:
         image = sitk.GetArrayFromImage(image)
 

--- a/wsireg/wsireg2d.py
+++ b/wsireg/wsireg2d.py
@@ -988,6 +988,7 @@ class WsiReg2D(object):
         self,
         file_writer="ome.tiff",
         transform_non_reg=True,
+        remove_merged=True,
         to_original_size=True,
     ):
         """
@@ -998,6 +999,13 @@ class WsiReg2D(object):
         file_writer : str
             output type to use, sitk writes a single resolution tiff, "zarr" writes an ome-zarr multiscale
             zarr store
+        transform_non_reg : bool
+            whether to write the images that aren't transformed during registration as well
+        remove_merged: bool
+            whether to remove images that are stored in merged store, if True, images that are merged
+            will not be written as individual images as well
+        to_original_size: bool
+            write images that have been cropped for registration back to their original coordinate space
         """
         image_fps = []
 
@@ -1013,17 +1021,18 @@ class WsiReg2D(object):
             reg_path_keys = list(self.reg_paths.keys())
             nonreg_keys = self._find_nonreg_modalities()
 
-            for merge_mod in merge_modalities:
-                try:
-                    m_idx = reg_path_keys.index(merge_mod)
-                    reg_path_keys.pop(m_idx)
-                except ValueError:
-                    pass
-                try:
-                    m_idx = nonreg_keys.index(merge_mod)
-                    nonreg_keys.pop(m_idx)
-                except ValueError:
-                    pass
+            if remove_merged:
+                for merge_mod in merge_modalities:
+                    try:
+                        m_idx = reg_path_keys.index(merge_mod)
+                        reg_path_keys.pop(m_idx)
+                    except ValueError:
+                        pass
+                    try:
+                        m_idx = nonreg_keys.index(merge_mod)
+                        nonreg_keys.pop(m_idx)
+                    except ValueError:
+                        pass
 
             for modality in reg_path_keys:
                 (


### PR DESCRIPTION
This PR updates the `WsiReg2D.transform_images()` to include the `remove_merged` kwarg. Setting this to `false` will write a merged version of the image as well as an unmerged version. This PR also includes an improve to image casting to that consumes less memory. 

Closes #20. 