### PR TITLE
Add ability to mix data types in final merger

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ itk-elastix
 SimpleITK
 aicsimageio[czi]
 pydantic
+ome-types

--- a/tests/fixtures/test-config5.yaml
+++ b/tests/fixtures/test-config5.yaml
@@ -1,0 +1,59 @@
+project_name: VAN0006-LK-2-85
+output_dir: fill
+cache_images: true
+modalities:
+  preAF-IMS:
+    image_filepath: private_data/VAN0006-LK-2-85-AF_preIMS_unregistered.czi
+    image_res: 0.65
+    preprocessing:
+      image_type: FL
+      contrast_enhance: true
+      as_uint8: true
+      downsampling: 4
+    output_res: 3.9
+
+  preAF-MxIF:
+    image_filepath: private_data/VAN0006-LK-2-86-AF_preMxIF_unregistered.czi
+    image_res: 0.65
+    preprocessing:
+      image_type: FL
+      contrast_enhance: true
+      as_uint8: true
+      rot_cc: 270
+      flip: h
+      downsampling: 4
+    output_res: 3.9
+
+  PAS-IMS:
+    image_filepath: private_data/VAN0006-LK-2-85-PAS_unregistered.scn
+    image_res: 0.5
+    preprocessing:
+      image_type: FL
+      contrast_enhance: false
+      as_uint8: true
+      rot_cc: -90
+      downsampling: 4
+    mask: null
+    output_res: 3.9
+
+reg_paths:
+  reg_path_0:
+    src_modality_name: preAF-MxIF
+    tgt_modality_name: preAF-IMS
+    thru_modality: null
+    reg_params:
+    - rigid
+    - affine
+    - nl
+  reg_path_1:
+    src_modality_name: PAS-IMS
+    tgt_modality_name: preAF-IMS
+    thru_modality: null
+    reg_params:
+      - rigid
+      - affine
+merge_modalities:
+  all-data-merge:
+    - preAF-IMS
+    - preAF-MxIF
+    - PAS-IMS

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -385,7 +385,7 @@ def test_MergeOmeTiffWriter_mix_merge(
     )
 
     by_plane_fp = merge_ometiffwriter.merge_write_image_by_plane(
-        "merge_testimage_by_plane",
+        "merge_testimage_by_plane_mix",
         ["1", "2", "3"],
         output_dir=str(data_out_dir),
     )

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -363,8 +363,11 @@ def test_MergeOmeTiffWriter_mc(simple_transform_affine_nl, data_out_dir):
     assert np.array_equal(im_plane[3:6, :, :], im_plane_s2)
     assert np.array_equal(im_plane[6:9, :, :], im_plane_s3)
 
+
 @pytest.mark.usefixtures("simple_transform_affine_nl")
-def test_MergeOmeTiffWriter_mix_merge(simple_transform_affine_nl, data_out_dir):
+def test_MergeOmeTiffWriter_mix_merge(
+    simple_transform_affine_nl, data_out_dir
+):
 
     reg_image1 = np.random.randint(0, 255, (1024, 1024, 3), dtype=np.uint16)
     reg_image2 = np.random.randint(0, 255, (3, 1024, 1024), dtype=np.uint16)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,8 +1,7 @@
 import pytest
 from pathlib import Path
-from time import time
 import numpy as np
-from tifffile import imread, imwrite
+from tifffile import imread
 from wsireg.reg_images.loader import reg_image_loader
 from wsireg.reg_images.merge_reg_image import MergeRegImage
 from wsireg.writers.ome_tiff_writer import OmeTiffWriter
@@ -363,3 +362,31 @@ def test_MergeOmeTiffWriter_mc(simple_transform_affine_nl, data_out_dir):
     assert np.array_equal(im_plane[0:3, :, :], im_plane_s1)
     assert np.array_equal(im_plane[3:6, :, :], im_plane_s2)
     assert np.array_equal(im_plane[6:9, :, :], im_plane_s3)
+
+@pytest.mark.usefixtures("simple_transform_affine_nl")
+def test_MergeOmeTiffWriter_mix_merge(simple_transform_affine_nl, data_out_dir):
+
+    reg_image1 = np.random.randint(0, 255, (1024, 1024, 3), dtype=np.uint16)
+    reg_image2 = np.random.randint(0, 255, (3, 1024, 1024), dtype=np.uint16)
+    reg_image3 = np.random.randint(0, 255, (3, 1024, 1024), dtype=np.uint8)
+
+    mreg_image = MergeRegImage(
+        [reg_image1, reg_image2, reg_image3],
+        [1, 1, 1],
+        channel_names=[["1", "2", "3"], ["1", "2", "3"], ["1", "2", "3"]],
+    )
+
+    rts = RegTransformSeq(simple_transform_affine_nl)
+    merge_ometiffwriter = MergeOmeTiffWriter(
+        mreg_image, reg_seq_transforms=[rts, rts, rts]
+    )
+
+    by_plane_fp = merge_ometiffwriter.merge_write_image_by_plane(
+        "merge_testimage_by_plane",
+        ["1", "2", "3"],
+        output_dir=str(data_out_dir),
+    )
+
+    im_plane = imread(by_plane_fp)
+
+    assert im_plane.shape[0] == 9

--- a/tests/test_wsireg.py
+++ b/tests/test_wsireg.py
@@ -1,13 +1,22 @@
 import pytest
 import os
+import random
+import string
 import numpy as np
 from pathlib import Path
+from tifffile import TiffFile
+from ome_types import from_xml
 from wsireg.wsireg2d import WsiReg2D
 from wsireg.reg_images.loader import reg_image_loader
 from wsireg.parameter_maps.preprocessing import ImagePreproParams
 
 HERE = os.path.dirname(__file__)
 GEOJSON_FP = os.path.join(HERE, "fixtures/polygons.geojson")
+
+
+def gen_project_name_str():
+    letters = string.ascii_lowercase
+    return ''.join(random.choice(letters) for i in range(10))
 
 
 @pytest.fixture(scope="session")
@@ -23,13 +32,14 @@ def data_im_fp(tmpdir_factory):
 
 
 def test_WsiReg2D_instantiation(data_out_dir):
-    wsi_reg = WsiReg2D("test_proj", str(data_out_dir))
-    assert wsi_reg.project_name == "test_proj"
+    pstr = gen_project_name_str()
+    wsi_reg = WsiReg2D(pstr, str(data_out_dir))
+    assert wsi_reg.project_name == pstr
     assert wsi_reg.output_dir == Path(str(data_out_dir))
 
 
 def test_wsireg2d_add_modality_w_fp(data_out_dir, data_im_fp):
-    wsi_reg = WsiReg2D("test_proj1", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(data_im_fp)
     wsi_reg.add_modality(
         "test_mod",
@@ -52,7 +62,7 @@ def test_wsireg2d_add_modality_w_fp(data_out_dir, data_im_fp):
 
 @pytest.mark.usefixtures("im_mch_np")
 def test_wsireg2d_add_modality_w_np(data_out_dir, im_mch_np):
-    wsi_reg = WsiReg2D("test_proj2", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     wsi_reg.add_modality(
         "test_mod",
         im_mch_np,
@@ -75,7 +85,7 @@ def test_wsireg2d_add_modality_w_np(data_out_dir, im_mch_np):
 
 
 def test_wsireg2d_add_modality_check_names(data_out_dir, data_im_fp):
-    wsi_reg = WsiReg2D("test_proj3", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(data_im_fp)
     modality_name1 = "test_mod1"
     modality_name2 = "test_mod2"
@@ -100,7 +110,7 @@ def test_wsireg2d_add_modality_check_names(data_out_dir, data_im_fp):
 
 
 def test_wsireg2d_add_reg_path_single(data_out_dir, data_im_fp):
-    wsi_reg = WsiReg2D("test_proj4", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(data_im_fp)
     modality_name1 = "test_mod1"
     modality_name2 = "test_mod2"
@@ -128,7 +138,7 @@ def test_wsireg2d_add_reg_path_single(data_out_dir, data_im_fp):
 
 
 def test_wsireg2d_add_modality_duplicated_error(data_out_dir, data_im_fp):
-    wsi_reg = WsiReg2D("test_proj5", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(data_im_fp)
     wsi_reg.add_modality(
         "test_mod",
@@ -148,7 +158,7 @@ def test_wsireg2d_add_modality_duplicated_error(data_out_dir, data_im_fp):
 
 
 def test_wsireg2d_add_merge_modality_notfound(data_out_dir, data_im_fp):
-    wsi_reg = WsiReg2D("test_proj_merge_nf", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(data_im_fp)
     wsi_reg.add_modality(
         "test_mod1",
@@ -171,7 +181,7 @@ def test_wsireg2d_add_merge_modality_notfound(data_out_dir, data_im_fp):
 
 @pytest.mark.usefixtures("disk_im_gry")
 def test_wsireg_run_reg(data_out_dir, disk_im_gry):
-    wsi_reg = WsiReg2D("test_proj_run_reg", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(disk_im_gry)
 
     wsi_reg.add_modality(
@@ -203,7 +213,7 @@ def test_wsireg_run_reg(data_out_dir, disk_im_gry):
 
 @pytest.mark.usefixtures("disk_im_gry")
 def test_wsireg_run_reg_with_crop(data_out_dir, disk_im_gry):
-    wsi_reg = WsiReg2D("test_proj7", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(disk_im_gry)
 
     wsi_reg.add_modality(
@@ -256,7 +266,7 @@ def test_wsireg_run_reg_with_crop(data_out_dir, disk_im_gry):
 
 @pytest.mark.usefixtures("disk_im_gry")
 def test_wsireg_run_reg_with_flip_crop(data_out_dir, disk_im_gry):
-    wsi_reg = WsiReg2D("test_proj8", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(disk_im_gry)
 
     wsi_reg.add_modality(
@@ -306,7 +316,7 @@ def test_wsireg_run_reg_with_flip_crop(data_out_dir, disk_im_gry):
 
 @pytest.mark.usefixtures("disk_im_gry")
 def test_wsireg_run_reg_with_crop_merge(data_out_dir, disk_im_gry):
-    wsi_reg = WsiReg2D("test_proj9", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(disk_im_gry)
 
     wsi_reg.add_modality(
@@ -358,7 +368,7 @@ def test_wsireg_run_reg_with_crop_merge(data_out_dir, disk_im_gry):
 
 
 def test_wsireg_run_reg_wmerge(data_out_dir, disk_im_gry):
-    wsi_reg = WsiReg2D("test_proj-merge-work", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(disk_im_gry)
 
     wsi_reg.add_modality(
@@ -390,7 +400,7 @@ def test_wsireg_run_reg_wmerge(data_out_dir, disk_im_gry):
 
 
 def test_wsireg_run_reg_wmerge_and_indiv(data_out_dir, disk_im_gry):
-    wsi_reg = WsiReg2D("test_proj-merge-and-unmerge", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(disk_im_gry)
 
     wsi_reg.add_modality(
@@ -441,7 +451,7 @@ def test_wsireg_run_reg_wmerge_and_indiv(data_out_dir, disk_im_gry):
 
 
 def test_wsireg_run_reg_wattachment(data_out_dir, disk_im_gry):
-    wsi_reg = WsiReg2D("test_proj-attach", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     im1 = np.random.randint(0, 255, (2048, 2048), dtype=np.uint16)
     im2 = np.random.randint(0, 255, (2048, 2048), dtype=np.uint16)
 
@@ -461,6 +471,7 @@ def test_wsireg_run_reg_wattachment(data_out_dir, disk_im_gry):
         channel_colors=["red"],
     )
     wsi_reg.add_attachment_images("mod2", "attached", im2, image_res=0.65)
+    wsi_reg.add_attachment_images("mod1", "attached2", im1, image_res=0.65)
 
     wsi_reg.add_reg_path(
         "mod2", "mod1", reg_params=["rigid_test", "affine_test"]
@@ -473,13 +484,57 @@ def test_wsireg_run_reg_wattachment(data_out_dir, disk_im_gry):
 
     regim = reg_image_loader(im_fps[0], 0.65)
     attachim = reg_image_loader(im_fps[1], 0.65)
+    attachim2 = reg_image_loader(im_fps[2], 0.65)
 
     assert np.array_equal(regim.image.compute(), attachim.image.compute())
+    assert np.array_equal(im1, attachim2.image.compute())
+
+
+def test_wsireg_run_reg_wattachment_ds2(data_out_dir, disk_im_gry):
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
+    im1 = np.random.randint(0, 255, (2048, 2048), dtype=np.uint16)
+    im2 = np.random.randint(0, 255, (2048, 2048), dtype=np.uint16)
+
+    wsi_reg.add_modality(
+        "mod1",
+        im1,
+        0.65,
+        channel_names=["test"],
+        channel_colors=["red"],
+        preprocessing={"downsampling": 2},
+    )
+
+    wsi_reg.add_modality(
+        "mod2",
+        im2,
+        0.65,
+        channel_names=["test"],
+        channel_colors=["red"],
+        preprocessing={"downsampling": 2},
+    )
+    wsi_reg.add_attachment_images("mod2", "attached", im2, image_res=0.65)
+    wsi_reg.add_attachment_images("mod1", "attached2", im1, image_res=0.65)
+
+    wsi_reg.add_reg_path(
+        "mod2", "mod1", reg_params=["rigid_test", "affine_test"]
+    )
+
+    wsi_reg.register_images()
+    im_fps = wsi_reg.transform_images(transform_non_reg=False)
+
+    wsi_reg.save_transformations()
+
+    regim = reg_image_loader(im_fps[0], 0.65)
+    attachim = reg_image_loader(im_fps[1], 0.65)
+    attachim2 = reg_image_loader(im_fps[2], 0.65)
+
+    assert np.array_equal(regim.image.compute(), attachim.image.compute())
+    assert np.array_equal(im1, attachim2.image.compute())
 
 
 @pytest.mark.usefixtures("disk_im_gry")
 def test_wsireg_run_reg_shapes(data_out_dir, disk_im_gry):
-    wsi_reg = WsiReg2D("test_proj_run_wpts", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(disk_im_gry)
 
     wsi_reg.add_modality(
@@ -514,7 +569,7 @@ def test_wsireg_run_reg_shapes(data_out_dir, disk_im_gry):
 
 @pytest.mark.usefixtures("disk_im_gry")
 def test_wsireg_run_reg_changeres(data_out_dir, disk_im_gry):
-    wsi_reg = WsiReg2D("test_proj_run_wpts", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(disk_im_gry)
 
     wsi_reg.add_modality(
@@ -547,7 +602,7 @@ def test_wsireg_run_reg_changeres(data_out_dir, disk_im_gry):
 
 @pytest.mark.usefixtures("disk_im_gry")
 def test_wsireg_run_reg_downsampling_m1(data_out_dir, disk_im_gry):
-    wsi_reg = WsiReg2D("test_proj_run_ds1", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(disk_im_gry)
 
     wsi_reg.add_modality(
@@ -580,7 +635,7 @@ def test_wsireg_run_reg_downsampling_m1(data_out_dir, disk_im_gry):
 
 @pytest.mark.usefixtures("disk_im_gry")
 def test_wsireg_run_reg_downsampling_m1_prepro(data_out_dir, disk_im_gry):
-    wsi_reg = WsiReg2D("test_proj_run_ds2", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(disk_im_gry)
 
     wsi_reg.add_modality(
@@ -613,7 +668,7 @@ def test_wsireg_run_reg_downsampling_m1_prepro(data_out_dir, disk_im_gry):
 
 @pytest.mark.usefixtures("disk_im_gry")
 def test_wsireg_run_reg_downsampling_m1m2(data_out_dir, disk_im_gry):
-    wsi_reg = WsiReg2D("test_proj_run_ds3", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(disk_im_gry)
 
     wsi_reg.add_modality(
@@ -647,7 +702,7 @@ def test_wsireg_run_reg_downsampling_m1m2(data_out_dir, disk_im_gry):
 def test_wsireg_run_reg_downsampling_m1m2_changeores(
     data_out_dir, disk_im_gry
 ):
-    wsi_reg = WsiReg2D("test_proj_run_ds4", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(disk_im_gry)
 
     wsi_reg.add_modality(
@@ -680,7 +735,7 @@ def test_wsireg_run_reg_downsampling_m1m2_changeores(
 
 @pytest.mark.usefixtures("disk_im_gry")
 def test_wsireg_run_reg_downsampling_m2_prepro(data_out_dir, disk_im_gry):
-    wsi_reg = WsiReg2D("test_proj_run_ds5", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(disk_im_gry)
 
     wsi_reg.add_modality(
@@ -712,7 +767,7 @@ def test_wsireg_run_reg_downsampling_m2_prepro(data_out_dir, disk_im_gry):
 
 @pytest.mark.usefixtures("disk_im_gry")
 def test_wsireg_run_reg_downsampling_m1m2_merge(data_out_dir, disk_im_gry):
-    wsi_reg = WsiReg2D("test_proj_run_ds6", str(data_out_dir))
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
     img_fp1 = str(disk_im_gry)
 
     wsi_reg.add_modality(
@@ -743,3 +798,183 @@ def test_wsireg_run_reg_downsampling_m1m2_merge(data_out_dir, disk_im_gry):
     regim = reg_image_loader(im_fps[0], 0.65)
 
     assert regim.im_dims == (2, 2048, 2048)
+
+
+@pytest.mark.usefixtures("disk_im_gry")
+def test_wsireg_run_reg_downsampling_m1m2_merge_no_prepro(
+    data_out_dir, disk_im_gry
+):
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
+    img_fp1 = str(disk_im_gry)
+
+    wsi_reg.add_modality(
+        "mod1",
+        img_fp1,
+        0.65,
+        channel_names=["test"],
+        channel_colors=["red"],
+        preprocessing={"downsampling": 2},
+    )
+
+    wsi_reg.add_modality(
+        "mod2",
+        img_fp1,
+        0.65,
+        channel_names=["test"],
+        channel_colors=["red"],
+        preprocessing={"downsampling": 2},
+    )
+
+    wsi_reg.add_reg_path("mod1", "mod2", reg_params=["rigid_test"])
+    wsi_reg.add_merge_modalities("mod12-merge", ["mod1", "mod2"])
+    wsi_reg.register_images()
+
+    im_fps = wsi_reg.transform_images(
+        transform_non_reg=False, remove_merged=True
+    )
+    regim = reg_image_loader(im_fps[0], 0.65)
+
+    assert regim.im_dims == (2, 2048, 2048)
+
+
+@pytest.mark.usefixtures("disk_im_gry")
+def test_wsireg_run_reg_downsampling_m1m2_merge_ds_attach(
+    data_out_dir, disk_im_gry
+):
+    wsi_reg = WsiReg2D(gen_project_name_str(), str(data_out_dir))
+    img_fp1 = str(disk_im_gry)
+
+    wsi_reg.add_modality(
+        "mod1",
+        img_fp1,
+        0.65,
+        channel_names=["test"],
+        channel_colors=["red"],
+        preprocessing={"downsampling": 2},
+    )
+
+    wsi_reg.add_modality(
+        "mod2",
+        img_fp1,
+        0.65,
+        channel_names=["test"],
+        channel_colors=["red"],
+        preprocessing={"downsampling": 2},
+    )
+
+    wsi_reg.add_attachment_images(
+        "mod2",
+        "mod3",
+        img_fp1,
+        0.65,
+        channel_names=["test"],
+        channel_colors=["red"],
+    )
+    wsi_reg.add_reg_path("mod1", "mod2", reg_params=["rigid_test"])
+
+    wsi_reg.add_merge_modalities("mod12-merge", ["mod1", "mod2", "mod3"])
+    wsi_reg.register_images()
+
+    im_fps = wsi_reg.transform_images(
+        transform_non_reg=False, remove_merged=True
+    )
+    regim = reg_image_loader(im_fps[0], 0.65)
+    ome_data = from_xml(TiffFile(im_fps[0]).ome_metadata)
+
+    assert regim.im_dims == (3, 2048, 2048)
+    assert ome_data.images[0].pixels.physical_size_x == 0.65
+    assert ome_data.images[0].pixels.physical_size_y == 0.65
+    assert ome_data.images[0].pixels.size_x == 2048
+    assert ome_data.images[0].pixels.size_y == 2048
+    assert ome_data.images[0].pixels.size_c == 3
+
+
+@pytest.mark.usefixtures("disk_im_gry")
+def test_wsireg_run_reg_downsampling_from_cache(data_out_dir, disk_im_gry):
+    pstr = gen_project_name_str()
+    wsi_reg = WsiReg2D(pstr, str(data_out_dir))
+    img_fp1 = str(disk_im_gry)
+
+    wsi_reg.add_modality(
+        "mod1",
+        img_fp1,
+        0.65,
+        channel_names=["test"],
+        channel_colors=["red"],
+        preprocessing={"downsampling": 2},
+    )
+
+    wsi_reg.add_modality(
+        "mod2",
+        img_fp1,
+        0.65,
+        channel_names=["test"],
+        channel_colors=["red"],
+        preprocessing={"downsampling": 2},
+    )
+
+    wsi_reg.add_attachment_images(
+        "mod2",
+        "mod3",
+        img_fp1,
+        0.65,
+        channel_names=["test"],
+        channel_colors=["red"],
+    )
+    wsi_reg.add_reg_path("mod1", "mod2", reg_params=["rigid_test"])
+    wsi_reg.register_images()
+
+    im_fps_nocache = wsi_reg.transform_images(
+        transform_non_reg=True, remove_merged=True
+    )
+
+    regim_nocache = reg_image_loader(im_fps_nocache[0], 0.65)
+    regim_nocache_attach = reg_image_loader(im_fps_nocache[1], 0.65)
+    regim_nocache_br = reg_image_loader(im_fps_nocache[2], 0.65)
+
+    wsi_reg2 = WsiReg2D(pstr, str(data_out_dir))
+    img_fp1 = str(disk_im_gry)
+
+    wsi_reg2.add_modality(
+        "mod1",
+        img_fp1,
+        0.65,
+        channel_names=["test"],
+        channel_colors=["red"],
+        preprocessing={"downsampling": 2},
+    )
+
+    wsi_reg2.add_modality(
+        "mod2",
+        img_fp1,
+        0.65,
+        channel_names=["test"],
+        channel_colors=["red"],
+        preprocessing={"downsampling": 2},
+    )
+
+    wsi_reg2.add_attachment_images(
+        "mod2",
+        "mod3",
+        img_fp1,
+        0.65,
+        channel_names=["test"],
+        channel_colors=["red"],
+    )
+    wsi_reg2.add_reg_path("mod1", "mod2", reg_params=["rigid_test"])
+    wsi_reg2.register_images()
+
+    im_fps_cache = wsi_reg.transform_images(
+        transform_non_reg=True, remove_merged=True
+    )
+
+    regim_cache = reg_image_loader(im_fps_cache[0], 0.65)
+    regim_cache_attach = reg_image_loader(im_fps_cache[1], 0.65)
+    regim_cache_br = reg_image_loader(im_fps_cache[2], 0.65)
+
+    regim_nocache_attach.im_dims
+    regim_cache_attach.im_dims
+
+    assert regim_cache.im_dims == regim_nocache.im_dims
+    assert regim_cache_br.im_dims == regim_nocache_br.im_dims
+    assert regim_cache_attach.im_dims == regim_nocache_attach.im_dims

--- a/tests/test_wsireg_config.py
+++ b/tests/test_wsireg_config.py
@@ -149,6 +149,7 @@ def test_wsireg_config_full_exp_DICE_ds(config_fp, data_out_dir):
 
     assert all(np.asarray(dice_vals) > 0.8)
 
+
 @pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
 @pytest.mark.parametrize(
     "config_fp",
@@ -164,4 +165,4 @@ def test_wsireg_config_full_merge_rgb_mc(config_fp, data_out_dir):
     ri = reg_image_loader(im_fps[0], 1)
 
     assert ri.im_dtype == np.uint16
-    assert ri.im_dims[0] == 9
+    assert ri.im_dims == (9, 3993, 3397)

--- a/tests/test_wsireg_config.py
+++ b/tests/test_wsireg_config.py
@@ -7,6 +7,7 @@ import numpy as np
 import cv2
 from wsireg.wsireg2d import WsiReg2D
 from wsireg.reg_shapes import RegShapes
+from wsireg.reg_images.loader import reg_image_loader
 from wsireg.utils.config_utils import parse_check_reg_config
 
 
@@ -18,6 +19,7 @@ config1_fp = str(Path(FIXTURES_DIR) / "test-config1.yaml")
 config2_fp = str(Path(FIXTURES_DIR) / "test-config2.yaml")
 config3_fp = str(Path(FIXTURES_DIR) / "test-config3.yaml")
 config4_fp = str(Path(FIXTURES_DIR) / "test-config4.yaml")
+config5_fp = str(Path(FIXTURES_DIR) / "test-config5.yaml")
 
 SKIP_PRIVATE = False
 REASON = "private data"
@@ -146,3 +148,20 @@ def test_wsireg_config_full_exp_DICE_ds(config_fp, data_out_dir):
         dice_vals.append(compute_dice(gt, test_mask))
 
     assert all(np.asarray(dice_vals) > 0.8)
+
+@pytest.mark.skipif(SKIP_PRIVATE, reason=REASON)
+@pytest.mark.parametrize(
+    "config_fp",
+    [
+        (config5_fp),
+    ],
+)
+def test_wsireg_config_full_merge_rgb_mc(config_fp, data_out_dir):
+    wsi_reg1 = config_to_WsiReg2D(config_fp, data_out_dir)
+    wsi_reg1.add_data_from_config(config_fp)
+    wsi_reg1.register_images()
+    im_fps = wsi_reg1.transform_images()
+    ri = reg_image_loader(im_fps[0], 1)
+
+    assert ri.im_dtype == np.uint16
+    assert ri.im_dims[0] == 9

--- a/wsireg/reg_images/merge_reg_image.py
+++ b/wsireg/reg_images/merge_reg_image.py
@@ -57,12 +57,16 @@ class MergeRegImage(RegImage):
             images.append(imdata)
 
         if all([im.im_dtype == images[0].im_dtype for im in images]) is False:
-            warn("MergeRegImage created with mixed data types, writing will cast "
-                 "to the largest data type")
+            warn(
+                "MergeRegImage created with mixed data types, writing will cast "
+                "to the largest data type"
+            )
 
         if any([im.is_rgb for im in images]) is True:
-            warn("MergeRegImage does not support writing merged interleaved RGB "
-                 "Data will be written as multi-channel")
+            warn(
+                "MergeRegImage does not support writing merged interleaved RGB "
+                "Data will be written as multi-channel"
+            )
 
         self.images = images
         self.image_fps = image_fp

--- a/wsireg/reg_images/merge_reg_image.py
+++ b/wsireg/reg_images/merge_reg_image.py
@@ -1,3 +1,4 @@
+from warnings import warn
 import numpy as np
 from wsireg.reg_images.loader import reg_image_loader
 from wsireg.reg_images.reg_image import RegImage
@@ -56,14 +57,12 @@ class MergeRegImage(RegImage):
             images.append(imdata)
 
         if all([im.im_dtype == images[0].im_dtype for im in images]) is False:
-            raise ValueError(
-                "MergeRegImage requires a list of images with matching data type"
-            )
+            warn("MergeRegImage created with mixed data types, writing will cast "
+                 "to the largest data type")
 
         if any([im.is_rgb for im in images]) is True:
-            raise ValueError(
-                "MergeRegImage does not support merger of RGB images"
-            )
+            warn("MergeRegImage does not support writing merged interleaved RGB "
+                 "Data will be written as multi-channel")
 
         self.images = images
         self.image_fps = image_fp

--- a/wsireg/utils/tform_utils.py
+++ b/wsireg/utils/tform_utils.py
@@ -1,3 +1,4 @@
+from typing import Tuple, Union
 from pathlib import Path
 import json
 import numpy as np
@@ -575,6 +576,16 @@ def sitk_transform_image(image, final_tform, composite_transform):
     resampler.SetTransform(composite_transform)
     image = resampler.Execute(image)
     return image
+
+
+def identity_elx_transform(
+    image_size: Tuple[int, int],
+    image_spacing: Union[Tuple[int, int], Tuple[float, float]],
+):
+    identity = BASE_RIG_TFORM
+    identity.update({"Size": [str(i) for i in image_size]})
+    identity.update({"Spacing": [str(i) for i in image_spacing]})
+    return identity
 
 
 #

--- a/wsireg/writers/merge_ome_tiff_writer.py
+++ b/wsireg/writers/merge_ome_tiff_writer.py
@@ -262,9 +262,7 @@ class MergeOmeTiffWriter:
                     options = dict(
                         tile=(tile_size, tile_size),
                         compression=self.compression,
-                        photometric="rgb"
-                        if merge_image.is_rgb
-                        else "minisblack",
+                        photometric="minisblack",
                         metadata=None,
                     )
                     # write OME-XML to the ImageDescription tag of the first page

--- a/wsireg/wsireg2d.py
+++ b/wsireg/wsireg2d.py
@@ -1451,7 +1451,7 @@ class WsiReg2D(object):
                 self.transformations = self.reg_graph_edges
 
         if reg_config.get("merge_modalities"):
-            for mn, mm in reg_config["merge_modalities"]:
+            for mn, mm in reg_config["merge_modalities"].items():
                 self.add_merge_modalities(mn, mm)
 
     def reset_registered_modality(self, modalities):

--- a/wsireg/wsireg2d.py
+++ b/wsireg/wsireg2d.py
@@ -744,27 +744,16 @@ class WsiReg2D(object):
                     mask=tgt_mask,
                 )
 
-                self._preprocessed_image_spacings.update(
-                    {
-                        src_name: (
-                            src_reg_image.image_res,
-                            src_reg_image.image_res,
-                        )
-                    }
-                )
-
-                self._preprocessed_image_spacings.update(
-                    {
-                        tgt_name: (
-                            tgt_reg_image.image_res,
-                            tgt_reg_image.image_res,
-                        )
-                    }
-                )
-
                 src_reg_image.read_reg_image()
                 tgt_reg_image.read_reg_image()
 
+                self._preprocessed_image_spacings.update(
+                    {src_name: src_reg_image.reg_image.GetSpacing()}
+                )
+
+                self._preprocessed_image_spacings.update(
+                    {tgt_name: tgt_reg_image.reg_image.GetSpacing()}
+                )
                 self._preprocessed_image_sizes.update(
                     {src_name: src_reg_image.reg_image.GetSize()}
                 )

--- a/wsireg/wsireg2d.py
+++ b/wsireg/wsireg2d.py
@@ -1,4 +1,5 @@
 from typing import Union, Optional, List, Dict, Tuple, Any
+from warnings import warn
 import time
 import yaml
 from pathlib import Path
@@ -27,6 +28,7 @@ from wsireg.utils.reg_utils import (
     json_to_pmap_dict,
 )
 from wsireg.utils.shape_utils import invert_nonrigid_transforms
+from wsireg.utils.tform_utils import identity_elx_transform
 
 
 class WsiReg2D(object):
@@ -101,24 +103,28 @@ class WsiReg2D(object):
 
         self.pairwise = False
 
-        self._modalities = {}
+        self._modalities = dict()
         self._modality_names = []
-        self._reg_paths = {}
+        self._reg_paths = dict()
         self._reg_graph_edges = []
-        self._transform_paths = {}
+        self._transform_paths = dict()
 
         self._transformations = None
+        self._preprocessed_image_sizes: Dict[str, Tuple[int, int]] = dict()
+        self._preprocessed_image_spacings: Dict[
+            str, Union[Tuple[int, int], Tuple[float, float]]
+        ] = dict()
 
-        self.n_modalities = None
-        self.n_registrations = None
+        self.n_modalities: Optional[int] = None
+        self.n_registrations: Optional[int] = None
 
-        self.attachment_images = {}
+        self.attachment_images = dict()
 
-        self._shape_sets = {}
+        self._shape_sets = dict()
         self._shape_set_names = []
 
-        self.merge_modalities = {}
-        self.original_size_transforms = {}
+        self.merge_modalities = dict()
+        self.original_size_transforms = dict()
 
         if config:
             self.add_data_from_config(config)
@@ -738,8 +744,33 @@ class WsiReg2D(object):
                     mask=tgt_mask,
                 )
 
+                self._preprocessed_image_spacings.update(
+                    {
+                        src_name: (
+                            src_reg_image.image_res,
+                            src_reg_image.image_res,
+                        )
+                    }
+                )
+
+                self._preprocessed_image_spacings.update(
+                    {
+                        tgt_name: (
+                            tgt_reg_image.image_res,
+                            tgt_reg_image.image_res,
+                        )
+                    }
+                )
+
                 src_reg_image.read_reg_image()
                 tgt_reg_image.read_reg_image()
+
+                self._preprocessed_image_sizes.update(
+                    {src_name: src_reg_image.reg_image.GetSize()}
+                )
+                self._preprocessed_image_sizes.update(
+                    {tgt_name: tgt_reg_image.reg_image.GetSize()}
+                )
 
                 if (
                     tgt_original_size_transform is None
@@ -847,18 +878,7 @@ class WsiReg2D(object):
         self._reg_graph_edges["reg_transforms"]
 
     def _collate_transformations(self):
-        transforms = {}
-        # for reg_edge in self.reg_graph_edges:
-        #     # if reg_edge["transforms"]["initial"]:
-        #     #     initial_transforms = [
-        #     #         RegTransform(t) for t in reg_edge["transforms"]["initial"]
-        #     #     ]
-        #     # else:
-        #     #     initial_transforms = []
-        #     reg_edge["reg_transforms"] = {
-        #         'initial': reg_edge["transforms"]["initial"],
-        #         'registration': reg_edge["transforms"]["registration"],
-        #     }
+        transforms = dict()
         edge_modality_pairs = [v['modalities'] for v in self.reg_graph_edges]
         for modality, tform_edges in self.transform_paths.items():
             full_tform_seq = RegTransformSeq()
@@ -889,15 +909,28 @@ class WsiReg2D(object):
         return transforms
 
     def _prepare_nonreg_image_transform(
-        self, modality_key, to_original_size=True
+        self,
+        modality_key,
+        attachment=False,
+        attachment_modality=None,
+        to_original_size=True,
     ):
-        transformations = None
+
         print(
-            "transforming non-registered modality : {} ".format(modality_key)
+            "preparing transforms for non-registered modality : {} ".format(
+                modality_key
+            )
         )
         output_path = self.output_dir / "{}-{}_registered".format(
             self.project_name, modality_key
         )
+
+        if attachment:
+            im_data_key = copy(modality_key)
+            modality_key = attachment_modality
+
+        transformations = None
+
         im_data = self.modalities[modality_key]
 
         if (
@@ -927,7 +960,7 @@ class WsiReg2D(object):
             else:
                 transformations = orig_size_rt
 
-        if im_data["preprocessing"].downsampling and transformations:
+        if im_data["preprocessing"].downsampling > 1 and transformations:
             if not im_data["output_res"]:
                 output_spacing_target = im_data["image_res"]
                 transformations.set_output_spacing(
@@ -935,6 +968,31 @@ class WsiReg2D(object):
                 )
             else:
                 transformations.set_output_spacing(im_data["output_res"])
+
+        elif im_data["preprocessing"].downsampling > 1 and not transformations:
+            transformations = RegTransformSeq(
+                [
+                    RegTransform(
+                        identity_elx_transform(
+                            self._preprocessed_image_sizes[modality_key],
+                            self._preprocessed_image_spacings[modality_key],
+                        )
+                    )
+                ],
+                transform_seq_idx=[0],
+            )
+
+            if not im_data["output_res"]:
+                output_spacing_target = im_data["image_res"]
+                transformations.set_output_spacing(
+                    (output_spacing_target, output_spacing_target)
+                )
+            else:
+                transformations.set_output_spacing(im_data["output_res"])
+
+        if attachment:
+            im_data = self.modalities[im_data_key]
+
         return im_data, transformations, output_path
 
     def _prepare_reg_image_transform(
@@ -944,8 +1002,6 @@ class WsiReg2D(object):
         attachment_modality=None,
         to_original_size=True,
     ):
-        im_data = self.modalities[edge_key]
-
         if attachment:
             final_modality = self.reg_paths[attachment_modality][-1]
             transformations = copy(
@@ -957,13 +1013,17 @@ class WsiReg2D(object):
                 self.transformations[edge_key]["full-transform-seq"]
             )
 
-        print("transforming {} to {}".format(edge_key, final_modality))
-
         output_path = self.output_dir / "{}-{}_to_{}_registered".format(
             self.project_name,
             edge_key,
             final_modality,
         )
+
+        if attachment:
+            im_data_key = copy(edge_key)
+            edge_key = attachment_modality
+
+        im_data = self.modalities[edge_key]
 
         if (
             self.original_size_transforms.get(final_modality)
@@ -978,7 +1038,7 @@ class WsiReg2D(object):
             )
             transformations.append(orig_size_rt)
 
-        if im_data["preprocessing"].downsampling:
+        if im_data["preprocessing"].downsampling > 1:
             if not im_data["output_res"]:
                 output_spacing_target = self.modalities[final_modality][
                     "image_res"
@@ -991,6 +1051,9 @@ class WsiReg2D(object):
 
         elif im_data["output_res"]:
             transformations.set_output_spacing(im_data["output_res"])
+
+        if attachment:
+            im_data = self.modalities[im_data_key]
 
         return im_data, transformations, output_path
 
@@ -1026,111 +1089,82 @@ class WsiReg2D(object):
         return im_fp
 
     def _transform_write_merge_images(self, to_original_size=True):
+        def determine_attachment(sub_image):
+            if sub_image in self.attachment_images.keys():
+                attachment_modality = self.attachment_images[sub_image]
+                attachment = True
+            else:
+                attachment_modality = None
+                attachment = False
+            return attachment, attachment_modality
+
         for merge_name, sub_images in self.merge_modalities.items():
             im_fps = []
             im_res = []
             im_ch_names = []
             transformations = []
-            final_modalities = []
+
+            non_reg_modalities = self._find_nonreg_modalities()
+
             for sub_image in sub_images:
+                attachment, attachment_modality = determine_attachment(
+                    sub_image
+                )
                 im_data = self.modalities[sub_image]
                 im_fps.append(im_data["image_filepath"])
                 im_res.append(im_data["image_res"])
                 im_ch_names.append(im_data.get("channel_names"))
-
-                try:
-                    transforms = copy(
-                        self.transformations[sub_image]["full-transform-seq"]
-                    )
-
-                except KeyError:
-                    transforms = None
-
-                try:
-                    final_modalities.append(self.reg_paths[sub_image][-1])
-                except KeyError:
-
-                    initial_transforms = self._check_cache_modality(sub_image)[
-                        1
-                    ][0]
-                    if initial_transforms:
-                        initial_transforms = [
-                            RegTransform(t) for t in initial_transforms
-                        ]
-                        transforms = RegTransformSeq(
-                            initial_transforms,
-                            transform_seq_idx=[
-                                idx for idx in range(len(initial_transforms))
-                            ],
-                        )
-                    else:
-                        transforms = None
-
-                if im_data["preprocessing"].downsampling and transforms:
-                    if not im_data["output_res"]:
-                        try:
-                            final_modality = self.reg_paths[sub_image][-1]
-                        except KeyError:
-                            final_modality = sub_image
-
-                        output_spacing_target = self.modalities[
-                            final_modality
-                        ]["image_res"]
-                        transforms.set_output_spacing(
-                            (output_spacing_target, output_spacing_target)
-                        )
-                    else:
-                        transforms.set_output_spacing(im_data["output_res"])
-
-                elif (
-                    im_data["output_res"]
-                    and sub_image != final_modality
-                    and transforms
+                if (
+                    sub_image not in non_reg_modalities
+                    and attachment_modality not in non_reg_modalities
                 ):
-                    transforms.set_output_spacing(im_data["output_res"])
-
-                transformations.append(transforms)
-
-            if all(final_modalities):
-                final_modality = final_modalities[0]
-            else:
-                raise ValueError("final modalities do not match on merge")
-
-            if (
-                self.original_size_transforms.get(final_modality)
-                and to_original_size
-            ):
-                original_size_transform = self.original_size_transforms[
-                    final_modality
-                ]
-                for transformation in transformations:
-                    orig_size_rt = RegTransformSeq(
-                        RegTransform(original_size_transform),
-                        transform_seq_idx=[0],
+                    (
+                        _,
+                        sub_im_transforms,
+                        _,
+                    ) = self._prepare_reg_image_transform(
+                        sub_image,
+                        attachment=attachment,
+                        attachment_modality=attachment_modality,
+                        to_original_size=to_original_size,
                     )
-                    transformation.append(orig_size_rt)
 
-            output_path = self.output_dir / "{}-{}_merged-registered".format(
-                self.project_name,
-                merge_name,
-            )
+                else:
 
-            merge_regimage = MergeRegImage(
-                im_fps,
-                im_res,
-                channel_names=im_ch_names,
-            )
+                    (
+                        _,
+                        sub_im_transforms,
+                        _,
+                    ) = self._prepare_nonreg_image_transform(
+                        sub_image,
+                        attachment=attachment,
+                        attachment_modality=attachment_modality,
+                        to_original_size=to_original_size,
+                    )
 
-            merge_ometiffwriter = MergeOmeTiffWriter(
-                merge_regimage, reg_seq_transforms=transformations
-            )
+                transformations.append(sub_im_transforms)
 
-            im_fp = merge_ometiffwriter.merge_write_image_by_plane(
-                output_path.stem,
-                sub_images,
-                output_dir=str(self.output_dir),
-            )
-            return im_fp
+        output_path = self.output_dir / "{}-{}_merged-registered".format(
+            self.project_name,
+            merge_name,
+        )
+
+        merge_regimage = MergeRegImage(
+            im_fps,
+            im_res,
+            channel_names=im_ch_names,
+        )
+
+        merge_ometiffwriter = MergeOmeTiffWriter(
+            merge_regimage, reg_seq_transforms=transformations
+        )
+
+        im_fp = merge_ometiffwriter.merge_write_image_by_plane(
+            output_path.stem,
+            sub_images,
+            output_dir=str(self.output_dir),
+        )
+        return im_fp
 
     def transform_images(
         self,
@@ -1192,6 +1226,7 @@ class WsiReg2D(object):
                     attachment=False,
                     to_original_size=to_original_size,
                 )
+
                 im_fp = self._transform_write_image(
                     im_data,
                     transformations,
@@ -1204,16 +1239,30 @@ class WsiReg2D(object):
                 modality,
                 attachment_modality,
             ) in self.attachment_images.items():
-                (
-                    im_data,
-                    transformations,
-                    output_path,
-                ) = self._prepare_reg_image_transform(
-                    modality,
-                    attachment=True,
-                    attachment_modality=attachment_modality,
-                    to_original_size=to_original_size,
-                )
+                if modality in merge_modalities and remove_merged:
+                    continue
+                if attachment_modality in self._find_nonreg_modalities():
+                    (
+                        im_data,
+                        transformations,
+                        output_path,
+                    ) = self._prepare_nonreg_image_transform(
+                        modality,
+                        attachment=True,
+                        attachment_modality=attachment_modality,
+                        to_original_size=to_original_size,
+                    )
+                else:
+                    (
+                        im_data,
+                        transformations,
+                        output_path,
+                    ) = self._prepare_reg_image_transform(
+                        modality,
+                        attachment=True,
+                        attachment_modality=attachment_modality,
+                        to_original_size=to_original_size,
+                    )
 
                 im_fp = self._transform_write_image(
                     im_data,
@@ -1222,15 +1271,19 @@ class WsiReg2D(object):
                     file_writer=file_writer,
                 )
                 image_fps.append(im_fp)
+
             if len(self.merge_modalities.items()) > 0:
                 im_fp = self._transform_write_merge_images(
                     to_original_size=to_original_size
                 )
                 image_fps.append(im_fp)
 
-        if transform_non_reg is True:
+        if transform_non_reg:
             # preprocess and save unregistered nodes
             for modality in nonreg_keys:
+                if modality in merge_modalities and remove_merged:
+                    continue
+
                 (
                     im_data,
                     transformations,
@@ -1361,24 +1414,30 @@ class WsiReg2D(object):
                 modality,
                 attachment_modality,
             ) in self.attachment_images.items():
+                if attachment_modality not in self._find_nonreg_modalities():
 
-                final_modality = self.reg_paths[attachment_modality][-1]
+                    final_modality = self.reg_paths[attachment_modality][-1]
 
-                output_path = (
-                    self.output_dir
-                    / "{}-{}_to_{}_transformations.json".format(
-                        self.project_name,
-                        modality,
-                        final_modality,
+                    output_path = (
+                        self.output_dir
+                        / "{}-{}_to_{}_transformations.json".format(
+                            self.project_name,
+                            modality,
+                            final_modality,
+                        )
                     )
-                )
 
-                tform_txt = self._transforms_to_txt(self.transformations[key])
+                    tform_txt = self._transforms_to_txt(
+                        self.transformations[key]
+                    )
 
-                with open(output_path, 'w') as fp:
-                    json.dump(tform_txt, fp, indent=4)
+                    with open(output_path, 'w') as fp:
+                        json.dump(tform_txt, fp, indent=4)
         else:
-            print("registration has not been executed for the graph")
+            warn(
+                "registration has not been executed for the graph "
+                "no transformations to save"
+            )
 
     def add_data_from_config(self, config_filepath):
 


### PR DESCRIPTION
Closes #28.

Following conversion in #22, when an image is RGB interleaved and another multi-channel non-interleaved, writing the data to a single OME-TIFF was not possible after registration, likewise true if images were of mixed prevision (i.e. one uint16, and another uint8). This PR casts the lower precision datatype to the higher precision type and writes RGB with interleaved to combine mixed image types and also contains some fixes for mixing downsampling and output resolutions.


ping @rjesud. This should do what you wanted now.