### PR TITLE
Fix error when passing a boolean mask

### DIFF
--- a/wsireg/reg_images/sitk_reg_image.py
+++ b/wsireg/reg_images/sitk_reg_image.py
@@ -36,7 +36,7 @@ class SitkRegImage(RegImage):
 
         self._n_ch = self._shape[2] if self.is_rgb else self._shape[0]
 
-        if mask:
+        if mask is not None:
             self._mask = self.read_mask(mask)
 
         self.pre_reg_transforms = pre_reg_transforms


### PR DESCRIPTION
When passing a boolean mask to `add_modality` (which is supported according to the type hints) using

```python
mask = np.zeros((3000, 3000), dtype="uint8")
mask [ 500:-500, 20:-500] = 1
```

It failed with

```pytb
File <redacted>/python3.10/site-packages/wsireg/reg_images/tifffile_reg_image.py:46, in TiffFileRegImage.__init__(self, image_fp, image_res, mask, pre_reg_transforms, preprocessing, channel_names, channel_colors)
     42 self._get_dim_info()
     44 self._dask_image = self._get_dask_image()
---> 46 if mask:
     47     self._mask = self.read_mask(mask)
     49 self.pre_reg_transforms = pre_reg_transforms

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

The fix is simple: check `if mask is None:` instead of `if mask:`.